### PR TITLE
Warning in host-check if 2M hugepages are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,5 @@ First release.
 
 ### v1.0.1 (2022-09-06)
 
-Emit a warning in `host-check` when 2M hugepages are used.
+- Emit a warning in `host-check` when 2M hugepages are used, as this is not a
+supported deployment use case.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,8 @@ First release.
 - Templates: MacVLAN launch-xrd example, xr-compose template
 - Sample xr-compose topologies: 'simple-bgp', 'bgp-ospf-triangle, 'segment-routing'
 - Tests: host-check UT
+
+
+### v1.0.1 (2022-09-06)
+
+Emit a warning in `host-check` when 2M hugepages are used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ First release.
 - Tests: host-check UT
 
 
-### v1.0.1 (2022-09-06)
+### v1.0.1 (2022-09-07)
 
 - Emit a warning in `host-check` when 2M hugepages are used, as this is not a
 supported deployment use case.

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -61,7 +61,9 @@ SHARED_MEM_MAX_PAGE_SIZE_GB = 2
 MIN_CPU_CORES_AVAILABLE = 2
 
 HUGEPAGE_MEMORY_GB = 3
-ACCEPTED_HUGEPAGE_SIZES_MB = [2, 1024]
+WARNING_HUGEPAGE_SIZE_MB = 2
+ACCEPTED_HUGEPAGE_SIZE_GB = 1
+ACCEPTED_HUGEPAGE_SIZE_MB = ACCEPTED_HUGEPAGE_SIZE_GB * 1024
 
 MIN_MEMLOCK_GB = 2
 
@@ -717,23 +719,6 @@ def _calc_hugepage_size_and_mem(
     return hugepages_size, hugepages_memory
 
 
-def _1gb_hugepages_supported() -> bool:
-    """
-    Checks whether 1GiB hugepages are supported.
-
-    :raise OSError:
-        If unable to read the required file.
-    """
-    output, _ = run_cmd("lscpu")
-    match = re.search(r"Flags:\s+(.+)", output)
-    if not match:
-        return False
-    cpu_exts = match.group(1).split(" ")
-    if "pdpe1gb" in cpu_exts:
-        return True
-    return False
-
-
 def check_hugepages() -> CheckFuncReturn:
     """Check hugepages are enabled with the required settings."""
     path = "/proc/meminfo"
@@ -760,21 +745,32 @@ def check_hugepages() -> CheckFuncReturn:
                     hugepages_memory,
                 ) = _calc_hugepage_size_and_mem(hugepages_lines)
 
-            if hugepages_size not in ACCEPTED_HUGEPAGE_SIZES_MB:
+            check_state = None
+            if hugepages_size == WARNING_HUGEPAGE_SIZE_MB:
+                msgs.append(
+                    f"{hugepages_size}MiB hugepages are available, but only {ACCEPTED_HUGEPAGE_SIZE_GB}GiB hugepages are\n"
+                    "supported for XRd deployment use cases."
+                )
+                # Just a warning for 2MiB hugepages as they're supported in lab
+                # cases
+                check_state = CheckState.WARNING
+            elif hugepages_size != ACCEPTED_HUGEPAGE_SIZE_MB:
                 msgs.append(
                     f"{hugepages_size}MiB hugepages are available, but XRd requires\n"
-                    f"1GiB (recommended) or 2MiB hugepages."
+                    f"{ACCEPTED_HUGEPAGE_SIZE_GB}GiB hugepages."
                 )
+                # Fail for any other hugepage size
+                check_state = CheckState.FAILED
             if hugepages_memory < HUGEPAGE_MEMORY_GB:
                 msgs.append(
                     f"Only {hugepages_memory:.1f}GiB of hugepage memory available, but XRd\n"
                     f"requires at least {HUGEPAGE_MEMORY_GB}GiB."
                 )
-            if (
-                hugepages_size not in ACCEPTED_HUGEPAGE_SIZES_MB
-                or hugepages_memory < HUGEPAGE_MEMORY_GB
-            ):
-                return CheckState.FAILED, "\n".join(msgs)
+                # Fail if there's not enough hugepage memory
+                check_state = CheckState.FAILED
+
+            if check_state is not None:
+                return check_state, "\n".join(msgs)
     except OSError:
         return (
             CheckState.WARNING,
@@ -791,31 +787,9 @@ def check_hugepages() -> CheckFuncReturn:
             f"or 2MiB hugepage size and at least {HUGEPAGE_MEMORY_GB}GiB of available\n"
             f"hugepage memory.",
         )
-    try:
-        if hugepages_size == 2 and _1gb_hugepages_supported():
-            return (
-                CheckState.WARNING,
-                f"{hugepages_memory:.1f}GiB of hugepages are available.\n"
-                f"The host is configured to use {hugepages_size}MiB hugepages - please\n"
-                f"reconfigure to use 1GiB hugepages for performance reasons.\n"
-                f"See the instructions at:\n"
-                f"https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt.",
-            )
-        elif hugepages_size == 2:
-            return (
-                CheckState.NEUTRAL,
-                f"{hugepages_memory:.1f}GiB of hugepages are available.\n"
-                f"The host only supports {hugepages_size}MiB hugepages - note that 1GiB\n"
-                f"hugepages are preferred for performance reasons.",
-            )
-        else:  # convert hugepage size to GiB
-            hugepages_size = hugepages_size // 1024
-            num_hugepgs = int(hugepages_memory // hugepages_size)
-    except subprocess.CalledProcessError as e:
-        return (
-            CheckState.WARNING,
-            f"Command {e.cmd!r} failed - unable to check whether 1GiB hugepages are supported.",
-        )
+
+    hugepages_size = hugepages_size // 1024
+    num_hugepgs = int(hugepages_memory // hugepages_size)
     return (
         CheckState.SUCCESS,
         f"{num_hugepgs} x {hugepages_size}GiB",

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -794,7 +794,7 @@ def check_hugepages() -> CheckFuncReturn:
     try:
         if hugepages_size == 2 and _1gb_hugepages_supported():
             return (
-                CheckState.NEUTRAL,
+                CheckState.WARNING,
                 f"{hugepages_memory:.1f}GiB of hugepages are available.\n"
                 f"The host is configured to use {hugepages_size}MiB hugepages - please\n"
                 f"reconfigure to use 1GiB hugepages for performance reasons.\n"

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -756,8 +756,8 @@ def check_hugepages() -> CheckFuncReturn:
                 check_state = CheckState.WARNING
             elif hugepages_size != ACCEPTED_HUGEPAGE_SIZE_MB:
                 msgs.append(
-                    f"{hugepages_size}MiB hugepages are available, but XRd requires\n"
-                    f"{ACCEPTED_HUGEPAGE_SIZE_GB}GiB hugepages."
+                    f"{hugepages_size}MiB hugepages are available, but XRd "
+                    f"requires {ACCEPTED_HUGEPAGE_SIZE_GB}GiB hugepages."
                 )
                 # Fail for any other hugepage size
                 check_state = CheckState.FAILED

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -1557,14 +1557,40 @@ class TestHugepages(_CheckTestBase):
         assert output == textwrap.dedent(
             """\
             FAIL -- Hugepages
-                    3MiB hugepages are available, but XRd requires
-                    1GiB hugepages.
+                    3MiB hugepages are available, but XRd requires 1GiB hugepages.
             """
         )
         assert not success
 
-    def test_insufficient_memory(self, capsys):
-        """Test the case where the hugepages memory is not sufficient."""
+    def test_insufficient_memory_1_GB(self, capsys):
+        """
+        Test the case where the hugepages memory is not sufficient and 1G
+        hugepages are being used.
+        """
+        hugepages_data = "\n".join(
+            [
+                "HugePages_Total: 512",
+                "Hugepagesize: 1 GB",
+                "HugePages_Free: 2",
+            ]
+        )
+        success, output = self.perform_check(
+            capsys, read_effects=hugepages_data
+        )
+        assert output == textwrap.dedent(
+            """\
+            FAIL -- Hugepages
+                    Only 2.0GiB of hugepage memory available, but XRd
+                    requires at least 3GiB.
+            """
+        )
+        assert not success
+
+    def test_insufficient_memory_2_MB(self, capsys):
+        """
+        Test the case where the hugepages memory is not sufficient and 2M
+        hugepages are being used.
+        """
         hugepages_data = "\n".join(
             [
                 "HugePages_Total: 512",

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -1607,7 +1607,7 @@ class TestHugepages(_CheckTestBase):
         )
         assert output == textwrap.dedent(
             """\
-            INFO -- Hugepages
+            WARN -- Hugepages
                     3.9GiB of hugepages are available.
                     The host is configured to use 2MiB hugepages - please
                     reconfigure to use 1GiB hugepages for performance reasons.
@@ -1615,7 +1615,7 @@ class TestHugepages(_CheckTestBase):
                     https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt.
             """
         )
-        assert success
+        assert not success
 
     def test_unaccepted_size(self, capsys):
         """Test the case where the hugepages size is not accepted."""

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -1501,7 +1501,6 @@ class TestHugepages(_CheckTestBase):
     check_group = "xrd-vrouter"
     check_name = "Hugepages"
     files = ["/proc/meminfo"]
-    cmds = ["lscpu"]
 
     def test_1_GB_hugepages(self, capsys):
         """Test the success case where 1 GiB hugepages are in use."""
@@ -1522,30 +1521,6 @@ class TestHugepages(_CheckTestBase):
         )
         assert success
 
-    def test_cpu_subproc_error(self, capsys):
-        """Test a subprocess error being raised when trying to parse 'lscpu'."""
-        hugepages_data = "\n".join(
-            [
-                "HugePages_Total: 2000",
-                "Hugepagesize: 2048 kB",
-                "HugePages_Free: 2000",
-            ]
-        )
-        success, output = self.perform_check(
-            capsys,
-            read_effects=hugepages_data,
-            cmd_effects=subprocess.CalledProcessError(
-                returncode=1, cmd="lscpu"
-            ),
-        )
-        assert output == textwrap.dedent(
-            """\
-            WARN -- Hugepages
-                    Command 'lscpu' failed - unable to check whether 1GiB hugepages are supported.
-            """
-        )
-        assert not success
-
     def test_2_MB_supported(self, capsys):
         """Test the case where only 2 MiB hugepages are supported and in use."""
         hugepages_data = "\n".join(
@@ -1555,64 +1530,14 @@ class TestHugepages(_CheckTestBase):
                 "HugePages_Free: 2000",
             ]
         )
-        cpu_data = "Flags: fpu vme"
         success, output = self.perform_check(
-            capsys, read_effects=hugepages_data, cmd_effects=cpu_data
-        )
-        assert output == textwrap.dedent(
-            """\
-            INFO -- Hugepages
-                    3.9GiB of hugepages are available.
-                    The host only supports 2MiB hugepages - note that 1GiB
-                    hugepages are preferred for performance reasons.
-            """
-        )
-        assert success
-
-    def test_2_MB_match_error(self, capsys):
-        """Test the case where 2 MiB hugepages are supported the regex match fails."""
-        hugepages_data = "\n".join(
-            [
-                "HugePages_Total: 2000",
-                "Hugepagesize: 2048 kB",
-                "HugePages_Free: 2000",
-            ]
-        )
-        cpu_data = "match error"
-        success, output = self.perform_check(
-            capsys, read_effects=hugepages_data, cmd_effects=cpu_data
-        )
-        assert output == textwrap.dedent(
-            """\
-            INFO -- Hugepages
-                    3.9GiB of hugepages are available.
-                    The host only supports 2MiB hugepages - note that 1GiB
-                    hugepages are preferred for performance reasons.
-            """
-        )
-        assert success
-
-    def test_2_MB_in_use_1_GB_supported(self, capsys):
-        """Test the case where 2 MiB hugepages are in use, but 1 GiB are supported."""
-        hugepages_data = "\n".join(
-            [
-                "HugePages_Total: 2000",
-                "Hugepagesize: 2048 kB",
-                "HugePages_Free: 2000",
-            ]
-        )
-        cpu_data = "Flags: fpu vme pdpe1gb"
-        success, output = self.perform_check(
-            capsys, read_effects=[hugepages_data, cpu_data]
+            capsys, read_effects=hugepages_data
         )
         assert output == textwrap.dedent(
             """\
             WARN -- Hugepages
-                    3.9GiB of hugepages are available.
-                    The host is configured to use 2MiB hugepages - please
-                    reconfigure to use 1GiB hugepages for performance reasons.
-                    See the instructions at:
-                    https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt.
+                    2MiB hugepages are available, but only 1GiB hugepages are
+                    supported for XRd deployment use cases.
             """
         )
         assert not success
@@ -1633,7 +1558,7 @@ class TestHugepages(_CheckTestBase):
             """\
             FAIL -- Hugepages
                     3MiB hugepages are available, but XRd requires
-                    1GiB (recommended) or 2MiB hugepages.
+                    1GiB hugepages.
             """
         )
         assert not success
@@ -1653,6 +1578,8 @@ class TestHugepages(_CheckTestBase):
         assert output == textwrap.dedent(
             """\
             FAIL -- Hugepages
+                    2MiB hugepages are available, but only 1GiB hugepages are
+                    supported for XRd deployment use cases.
                     Only 1.0GiB of hugepage memory available, but XRd
                     requires at least 3GiB.
             """


### PR DESCRIPTION
Make host-check warn if 2M hugepages are used, regardless of what is supported on the host.

Get rid of checks of what size hugepages are supported on the host.

Corresponding test updates.