### PR TITLE
Host check improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ It is planned to support 7.8.1 when this version is released.
 ### v1.0.2 (2022-09-21)
 
 - Do not run extra checks in `host-check` by default.
-- Make igb_uio a supported PCI driver, and only fail `host-check` if no interface driver is loaded.
-- Only check if IOMMU is enabled if vfio-pci is being used, and handle the case where IOMMU is unconfigurable.
+- Make igb_uio a supported PCI driver, only failing `host-check` if no interface driver is loaded.
+- Only check if IOMMU is enabled if vfio-pci is being used, and handle the case where the vfio-pci 'no IOMMU' mode is unconfigurable.
 
 
 ### v1.0.1 (2022-09-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The v1 release supports Cisco IOS-XR release version 7.7.1.
 It is planned to support 7.8.1 when this version is released.
 
 
+### v1.0.2 (2022-09-21)
+
+- Do not run extra checks in `host-check` by default.
+- Make igb_uio a supported PCI driver, and only fail `host-check` if no interface driver is loaded.
+- Only check if IOMMU is enabled if vfio-pci is being used, and handle the case where IOMMU is unconfigurable.
+
+
 ### v1.0.1 (2022-09-07)
 
 - Emit a warning in `host-check` when 2M hugepages are used, as this is not a

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1255,6 +1255,35 @@ def perform_checks(checks: List[Check]) -> bool:
     return not any(c.is_error() for c in results.values())
 
 
+def run_extra_checks(extra_checks: List[str]) -> Tuple[set[str], set[str]]:
+    extras_supported = set()
+    extras_not_supported = set()
+
+    print("")  # insert a newline
+    print_heading("Extra checks")
+    for extra_check in sorted(extra_checks):
+        print_subheading(f"{extra_check} checks")
+        extra_success = perform_checks(EXTRA_CHECKS_MAP[extra_check])
+        if extra_success:
+            extras_supported.add(extra_check)
+        else:
+            extras_not_supported.add(extra_check)
+
+    return (extras_supported, extras_not_supported)
+
+
+def print_extra_checks(supported: set[str], not_supported: set[str]) -> None:
+    print_without_newline(f"\n{DASHED_LINE}")
+    if supported:
+        print_without_newline(
+            "\nExtra checks passed: " + ", ".join(sorted(supported))
+        )
+    if not_supported:
+        print_without_newline(
+            "\nExtra checks failed: " + ", ".join(sorted(not_supported))
+        )
+
+
 def run_specified_checks(platform: str, extra_checks: List[str]) -> bool:
     """
     Run specified checks and report which platforms/extras are supported.
@@ -1266,25 +1295,14 @@ def run_specified_checks(platform: str, extra_checks: List[str]) -> bool:
     :return:
         Whether the XR platform checks succeeded.
     """
-    extra_failed = False
+    extras_not_supported: set[str] = set()
     print_heading(f"Platform checks - {platform}")
     platform_success = perform_checks(
         BASE_CHECKS + PLATFORM_CHECKS_MAP[platform]
     )
 
     if extra_checks is not None:  # check if any extra checks were specified
-        extras_supported = set()
-        extras_not_supported = set()
-
-        print("")  # insert a newline
-        print_heading("Extra checks")
-        for extra_check in sorted(extra_checks):
-            print_subheading(f"{extra_check} checks")
-            extra_success = perform_checks(EXTRA_CHECKS_MAP[extra_check])
-            if extra_success:
-                extras_supported.add(extra_check)
-            else:
-                extras_not_supported.add(extra_check)
+        extras_supported, extras_not_supported = run_extra_checks(extra_checks)
 
     print(f"\n{DOUBLE_DASHED_LINE}")
     if platform_success:
@@ -1297,23 +1315,13 @@ def run_specified_checks(platform: str, extra_checks: List[str]) -> bool:
         )
 
     if extra_checks is not None:
-        print_without_newline(f"\n{DASHED_LINE}")
-        if extras_supported:
-            print_without_newline(
-                "\nExtra checks passed: " + ", ".join(sorted(extras_supported))
-            )
-        if extras_not_supported:
-            extra_failed = True
-            print_without_newline(
-                "\nExtra checks failed: "
-                + ", ".join(sorted(extras_not_supported))
-            )
+        print_extra_checks(extras_supported, extras_not_supported)
     print(f"\n{DOUBLE_DASHED_LINE}")
 
-    return platform_success and not extra_failed
+    return platform_success and not extras_not_supported
 
 
-def run_all_checks() -> bool:
+def run_all_checks(extra_checks: List[str]) -> bool:
     """
     Run all checks and report which platforms/extras are supported.
 
@@ -1322,8 +1330,8 @@ def run_all_checks() -> bool:
     """
     platforms_supported = set()
     platforms_not_supported = set()
-    extras_supported = set()
-    extras_not_supported = set()
+    extras_supported: set[str] = set()
+    extras_not_supported: set[str] = set()
 
     print_heading("Platform checks")
     print_subheading("base checks")
@@ -1338,15 +1346,8 @@ def run_all_checks() -> bool:
         else:
             platforms_not_supported.add(platform)
 
-    print("")  # insert a newline
-    print_heading("Extra checks")
-    for extra, checks in EXTRA_CHECKS_MAP.items():
-        print_subheading(f"{extra} checks")
-        extra_success = perform_checks(checks)
-        if extra_success:
-            extras_supported.add(extra)
-        else:
-            extras_not_supported.add(extra)
+    if extra_checks:
+        extras_supported, extras_not_supported = run_extra_checks(extra_checks)
 
     print(f"\n{DOUBLE_DASHED_LINE}")
 
@@ -1364,16 +1365,8 @@ def run_all_checks() -> bool:
             + ", ".join(sorted(platforms_not_supported))
         )
 
-    print_without_newline(f"\n{DASHED_LINE}")
-
-    if extras_supported:
-        print_without_newline(
-            "\nExtra checks passed: " + ", ".join(sorted(extras_supported))
-        )
-    if extras_not_supported:
-        print_without_newline(
-            "\nExtra checks failed: " + ", ".join(sorted(extras_not_supported))
-        )
+    if extra_checks:
+        print_extra_checks(extras_supported, extras_not_supported)
 
     print(f"\n{DOUBLE_DASHED_LINE}")
 
@@ -1397,12 +1390,8 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         required=False,
         help="specify any extra checks to run",
     )
-    # specify some rules for using the arguments
     args = parser.parse_args(argv)
-    if args.extra_checks and not args.platform:
-        parser.error(
-            "The XR platform must be specified with: --platform [-p] XR_PLATFORM"
-        )
+
     return args
 
 
@@ -1412,7 +1401,7 @@ def main(argv: List[str]) -> NoReturn:
         success = run_specified_checks(args.platform, args.extra_checks)
     else:
         # We've already checked that extra checks aren't specified in this case.
-        success = run_all_checks()
+        success = run_all_checks(args.extra_checks)
     sys.exit(0 if success else 1)
 
 

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -867,7 +867,7 @@ def check_iommu() -> CheckFuncReturn:
     if not PCIDriver("vfio-pci").is_supported:
         return (
             CheckState.NEUTRAL,
-            "IOMMU is not required as the vfio-pci module is not loaded.",
+            "vfio-pci driver unavailable",
         )
     recommendation = "IOMMU is recommended for security when using the vfio-pci kernel driver."
     noiommu_filepath = "/sys/module/vfio/parameters/enable_unsafe_noiommu_mode"
@@ -1319,7 +1319,7 @@ def run_extra_checks(extra_checks: List[str]) -> Tuple[Set[str], Set[str]]:
         else:
             extras_not_supported.add(extra_check)
 
-    return (extras_supported, extras_not_supported)
+    return extras_supported, extras_not_supported
 
 
 def print_extra_checks(supported: Set[str], not_supported: Set[str]) -> None:
@@ -1450,7 +1450,6 @@ def main(argv: List[str]) -> NoReturn:
     if args.platform:
         success = run_specified_checks(args.platform, args.extra_checks)
     else:
-        # We've already checked that extra checks aren't specified in this case.
         success = run_all_checks(args.extra_checks)
     sys.exit(0 if success else 1)
 

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -30,6 +30,7 @@ import shlex
 import subprocess
 import sys
 import textwrap
+from dataclasses import dataclass
 from typing import (
     Any,
     Callable,
@@ -796,24 +797,68 @@ def check_hugepages() -> CheckFuncReturn:
     )
 
 
+@dataclass(frozen=True)
+class PCIDriver:
+    """
+    Class to represent a PCI driver.
+    """
+
+    name: str
+
+    @property
+    def is_supported(self) -> bool:
+        # The lsmod, loaded check, requires the underscore version of the kernel
+        # module name
+        return _is_module_loaded(
+            self.name.replace("-", "_")
+        ) or _is_module_builtin(self.name)
+
+    @property
+    def is_installed(self) -> bool:
+        return _is_module_installed(self.name)
+
+
 def check_interface_kernel_driver() -> CheckFuncReturn:
     """Check the required interface specific kernel driver is loaded."""
-    # The lsmod, loaded check, requires the underscore version of the kernel
-    # module name
-    if _is_module_loaded("vfio_pci") or _is_module_builtin("vfio-pci"):
-        return CheckState.SUCCESS, "vfio-pci loaded"
-    elif _is_module_installed("vfio-pci"):
-        return (
-            CheckState.FAILED,
-            "The kernel module vfio-pci is installed but not loaded.\n"
-            "Run 'modprobe vfio-pci' to load the module.",
-        )
+
+    pci_drivers = [PCIDriver("vfio-pci"), PCIDriver("igb_uio")]
+    supported_drivers = [
+        driver for driver in pci_drivers if driver.is_supported
+    ]
+    installed_not_supported = [
+        driver
+        for driver in pci_drivers
+        if driver not in supported_drivers and driver.is_installed
+    ]
+    supported_str = ", ".join(driver.name for driver in supported_drivers)
+    installed_not_supported_str = ", ".join(
+        driver.name for driver in installed_not_supported
+    )
+    if supported_drivers:
+        if installed_not_supported:
+            return (
+                CheckState.NEUTRAL,
+                f"The following PCI drivers are installed but not loaded: {installed_not_supported_str}.\n"
+                f"Loaded PCI drivers: {supported_str}.\n"
+                "Run 'modprobe <pci driver>' to load a driver.",
+            )
+        else:
+            return (CheckState.SUCCESS, f"Loaded PCI drivers: {supported_str}")
     else:
-        return (
-            CheckState.FAILED,
-            "The kernel module vfio-pci is not installed. It may be\n"
-            "possible to install using your distro's package manager.",
-        )
+        if installed_not_supported:
+            return (
+                CheckState.FAILED,
+                "None of the expected PCI drivers are loaded.\n"
+                f"The following PCI drivers are installed but not loaded: {installed_not_supported_str}.\n"
+                "Run 'modprobe <pci driver>' to load a driver.",
+            )
+        else:
+            return (
+                CheckState.FAILED,
+                "No PCI drivers are loaded or installed.\n"
+                "Must have either the vfio-pci or igb_uio kernel module loaded.\n"
+                "It may be possible to install using your distro's package manager.",
+            )
 
 
 def check_iommu() -> CheckFuncReturn:

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -40,6 +40,7 @@ from typing import (
     NamedTuple,
     NoReturn,
     Optional,
+    Set,
     Tuple,
     Union,
 )
@@ -1304,7 +1305,7 @@ def perform_checks(checks: List[Check]) -> bool:
     return not any(c.is_error() for c in results.values())
 
 
-def run_extra_checks(extra_checks: List[str]) -> Tuple[set[str], set[str]]:
+def run_extra_checks(extra_checks: List[str]) -> Tuple[Set[str], Set[str]]:
     extras_supported = set()
     extras_not_supported = set()
 
@@ -1321,7 +1322,7 @@ def run_extra_checks(extra_checks: List[str]) -> Tuple[set[str], set[str]]:
     return (extras_supported, extras_not_supported)
 
 
-def print_extra_checks(supported: set[str], not_supported: set[str]) -> None:
+def print_extra_checks(supported: Set[str], not_supported: Set[str]) -> None:
     print_without_newline(f"\n{DASHED_LINE}")
     if supported:
         print_without_newline(
@@ -1344,7 +1345,7 @@ def run_specified_checks(platform: str, extra_checks: List[str]) -> bool:
     :return:
         Whether the XR platform checks succeeded.
     """
-    extras_not_supported: set[str] = set()
+    extras_not_supported: Set[str] = set()
     print_heading(f"Platform checks - {platform}")
     platform_success = perform_checks(
         BASE_CHECKS + PLATFORM_CHECKS_MAP[platform]
@@ -1379,8 +1380,8 @@ def run_all_checks(extra_checks: List[str]) -> bool:
     """
     platforms_supported = set()
     platforms_not_supported = set()
-    extras_supported: set[str] = set()
-    extras_not_supported: set[str] = set()
+    extras_supported: Set[str] = set()
+    extras_not_supported: Set[str] = set()
 
     print_heading("Platform checks")
     print_subheading("base checks")

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -863,9 +863,15 @@ def check_interface_kernel_driver() -> CheckFuncReturn:
 
 def check_iommu() -> CheckFuncReturn:
     """Check IOMMU is set up correctly for the vfio-pci kernel module."""
+    if not PCIDriver("vfio-pci").is_supported:
+        return (
+            CheckState.NEUTRAL,
+            "IOMMU is not required as the vfio-pci module is not loaded.",
+        )
     recommendation = "IOMMU is recommended for security when using the vfio-pci kernel driver."
     noiommu_filepath = "/sys/module/vfio/parameters/enable_unsafe_noiommu_mode"
     iommu_dev_filepath = "/sys/class/iommu/*/devices/*"
+
     try:
         with open(noiommu_filepath, "r", encoding="utf-8") as f:
             no_iommu_mode = f.read().strip().upper() in ("Y", "1")
@@ -875,11 +881,9 @@ def check_iommu() -> CheckFuncReturn:
                     "vfio-pci is set up in no-IOMMU mode, but IOMMU is recommended for security.",
                 )
     except OSError:
-        return (
-            CheckState.WARNING,
-            "Failed to check whether vfio-pci 'no-IOMMU' mode is enabled by reading\n"
-            f"{noiommu_filepath}.\n" + recommendation,
-        )
+        # If the no-IOMMU file does not exist, then no-IOMMU mode can't be enabled.
+        pass
+
     # Check if IOMMU is enabled on the host
     try:
         iommu_devices = [

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -862,12 +862,10 @@ def check_iommu() -> CheckFuncReturn:
     if not PCIDriver("vfio-pci").is_supported():
         return CheckState.NEUTRAL, "vfio-pci driver unavailable"
 
-    # If igb_uio is supported, treat failures and warnings as info, because
-    # even though IOMMU isn't enabled, igb_uio can be used.
-    fail_state = CheckState.FAILED
+    # If igb_uio is supported, treat warnings as info, because even though
+    # IOMMU isn't enabled, igb_uio can be used.
     warning_state = CheckState.WARNING
     if PCIDriver("igb_uio").is_supported():
-        fail_state = CheckState.NEUTRAL
         warning_state = CheckState.NEUTRAL
 
     recommendation = "IOMMU is recommended for security when using the vfio-pci kernel driver."
@@ -893,7 +891,7 @@ def check_iommu() -> CheckFuncReturn:
         ]
         if not iommu_devices:  # check if the directory is empty
             return (
-                fail_state,
+                warning_state,
                 "The kernel module vfio-pci cannot be used, as IOMMU is not enabled.\n"
                 + recommendation,
             )
@@ -911,7 +909,9 @@ def check_iommu() -> CheckFuncReturn:
             r"pci@([\da-f]{4}:[\da-f]{2}:[\da-f]{2}\.[\da-f])\s+(\S+)", output
         )
         if not matches:
-            return fail_state, "no PCI network devices found"
+            # This should always be a warning - we need PCI devices whether
+            # we're using igb_uio or vfio-pci.
+            return CheckState.WARNING, "no PCI network devices found"
         network_devices = set()
         net_devices_dict = {}
         for match in matches:

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -792,10 +792,7 @@ def check_hugepages() -> CheckFuncReturn:
 
     hugepages_size = hugepages_size // 1024
     num_hugepgs = int(hugepages_memory // hugepages_size)
-    return (
-        CheckState.SUCCESS,
-        f"{num_hugepgs} x {hugepages_size}GiB",
-    )
+    return CheckState.SUCCESS, f"{num_hugepgs} x {hugepages_size}GiB"
 
 
 @dataclass(frozen=True)
@@ -806,7 +803,6 @@ class PCIDriver:
 
     name: str
 
-    @property
     def is_supported(self) -> bool:
         # The lsmod, loaded check, requires the underscore version of the kernel
         # module name
@@ -814,7 +810,6 @@ class PCIDriver:
             self.name.replace("-", "_")
         ) or _is_module_builtin(self.name)
 
-    @property
     def is_installed(self) -> bool:
         return _is_module_installed(self.name)
 
@@ -824,12 +819,12 @@ def check_interface_kernel_driver() -> CheckFuncReturn:
 
     pci_drivers = [PCIDriver("vfio-pci"), PCIDriver("igb_uio")]
     supported_drivers = [
-        driver for driver in pci_drivers if driver.is_supported
+        driver for driver in pci_drivers if driver.is_supported()
     ]
     installed_not_supported = [
         driver
         for driver in pci_drivers
-        if driver not in supported_drivers and driver.is_installed
+        if driver not in supported_drivers and driver.is_installed()
     ]
     supported_str = ", ".join(driver.name for driver in supported_drivers)
     installed_not_supported_str = ", ".join(
@@ -844,7 +839,7 @@ def check_interface_kernel_driver() -> CheckFuncReturn:
                 "Run 'modprobe <pci driver>' to load a driver.",
             )
         else:
-            return (CheckState.SUCCESS, f"Loaded PCI drivers: {supported_str}")
+            return CheckState.SUCCESS, f"Loaded PCI drivers: {supported_str}"
     else:
         if installed_not_supported:
             return (
@@ -864,11 +859,17 @@ def check_interface_kernel_driver() -> CheckFuncReturn:
 
 def check_iommu() -> CheckFuncReturn:
     """Check IOMMU is set up correctly for the vfio-pci kernel module."""
-    if not PCIDriver("vfio-pci").is_supported:
-        return (
-            CheckState.NEUTRAL,
-            "vfio-pci driver unavailable",
-        )
+    if not PCIDriver("vfio-pci").is_supported():
+        return CheckState.NEUTRAL, "vfio-pci driver unavailable"
+
+    # If igb_uio is supported, treat failures and warnings as info, because
+    # even though IOMMU isn't enabled, igb_uio can be used.
+    fail_state = CheckState.FAILED
+    warning_state = CheckState.WARNING
+    if PCIDriver("igb_uio").is_supported():
+        fail_state = CheckState.NEUTRAL
+        warning_state = CheckState.NEUTRAL
+
     recommendation = "IOMMU is recommended for security when using the vfio-pci kernel driver."
     noiommu_filepath = "/sys/module/vfio/parameters/enable_unsafe_noiommu_mode"
     iommu_dev_filepath = "/sys/class/iommu/*/devices/*"
@@ -878,7 +879,7 @@ def check_iommu() -> CheckFuncReturn:
             no_iommu_mode = f.read().strip().upper() in ("Y", "1")
             if no_iommu_mode:
                 return (
-                    CheckState.WARNING,
+                    warning_state,
                     "vfio-pci is set up in no-IOMMU mode, but IOMMU is recommended for security.",
                 )
     except OSError:
@@ -892,13 +893,13 @@ def check_iommu() -> CheckFuncReturn:
         ]
         if not iommu_devices:  # check if the directory is empty
             return (
-                CheckState.FAILED,
+                fail_state,
                 "The kernel module vfio-pci cannot be used, as IOMMU is not enabled.\n"
                 + recommendation,
             )
     except Exception:
         return (
-            CheckState.WARNING,
+            warning_state,
             f"Unable to check if IOMMU is enabled by listing {iommu_dev_filepath}.\n"
             + recommendation,
         )
@@ -910,7 +911,7 @@ def check_iommu() -> CheckFuncReturn:
             r"pci@([\da-f]{4}:[\da-f]{2}:[\da-f]{2}\.[\da-f])\s+(\S+)", output
         )
         if not matches:
-            return (CheckState.FAILED, "no PCI network devices found")
+            return fail_state, "no PCI network devices found"
         network_devices = set()
         net_devices_dict = {}
         for match in matches:
@@ -920,14 +921,14 @@ def check_iommu() -> CheckFuncReturn:
 
     except subprocess.SubprocessError:
         return (
-            CheckState.WARNING,
+            warning_state,
             f"The cmd {cmd!r} failed - unable to\n"
             "determine the network devices on the host. IOMMU is enabled.",
         )
     net_iommu_devices = network_devices & set(iommu_devices)
     if not net_iommu_devices:
         return (
-            CheckState.WARNING,
+            warning_state,
             "IOMMU enabled for vfio-pci, but no network PCI devices found.",
         )
     net_iommu_devs_list = []
@@ -1306,6 +1307,17 @@ def perform_checks(checks: List[Check]) -> bool:
 
 
 def run_extra_checks(extra_checks: List[str]) -> Tuple[Set[str], Set[str]]:
+    """
+    Run the specified extra checks, printing the results and returning the
+    checks that succeeded and failed.
+
+    :param extra_checks:
+        List of extra checks to perform.
+
+    :returns:
+        Tuple of the checks that succeeded, and the checks that failed.
+
+    """
     extras_supported = set()
     extras_not_supported = set()
 
@@ -1322,7 +1334,19 @@ def run_extra_checks(extra_checks: List[str]) -> Tuple[Set[str], Set[str]]:
     return extras_supported, extras_not_supported
 
 
-def print_extra_checks(supported: Set[str], not_supported: Set[str]) -> None:
+def print_extra_checks_summary(
+    supported: Set[str], not_supported: Set[str]
+) -> None:
+    """
+    Print a summary of the extra checks that passed and failed.
+
+    :param supported:
+        The checks that were successful.
+
+    :param not_supported:
+        The checks that were not successful.
+
+    """
     print_without_newline(f"\n{DASHED_LINE}")
     if supported:
         print_without_newline(
@@ -1334,16 +1358,19 @@ def print_extra_checks(supported: Set[str], not_supported: Set[str]) -> None:
         )
 
 
-def run_specified_checks(platform: str, extra_checks: List[str]) -> bool:
+def run_checks_specific_platform(
+    platform: str, extra_checks: List[str]
+) -> bool:
     """
-    Run specified checks and report which platforms/extras are supported.
+    Run checks for the given platform (including the base checks that are
+    required for all platforms).
 
     :param platform:
         The XR platform.
     :param extra_checks:
         A list of the extra checks.
     :return:
-        Whether the XR platform checks succeeded.
+        Whether all checks that were performed succeeded.
     """
     extras_not_supported: Set[str] = set()
     print_heading(f"Platform checks - {platform}")
@@ -1365,15 +1392,15 @@ def run_specified_checks(platform: str, extra_checks: List[str]) -> bool:
         )
 
     if extra_checks is not None:
-        print_extra_checks(extras_supported, extras_not_supported)
+        print_extra_checks_summary(extras_supported, extras_not_supported)
     print(f"\n{DOUBLE_DASHED_LINE}")
 
     return platform_success and not extras_not_supported
 
 
-def run_all_checks(extra_checks: List[str]) -> bool:
+def run_checks_all_platforms(extra_checks: List[str]) -> bool:
     """
-    Run all checks and report which platforms/extras are supported.
+    Run checks for all platforms and report which platforms are supported.
 
     :return:
         Whether at least one XR platform is supported.
@@ -1416,7 +1443,7 @@ def run_all_checks(extra_checks: List[str]) -> bool:
         )
 
     if extra_checks:
-        print_extra_checks(extras_supported, extras_not_supported)
+        print_extra_checks_summary(extras_supported, extras_not_supported)
 
     print(f"\n{DOUBLE_DASHED_LINE}")
 
@@ -1448,9 +1475,11 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
 def main(argv: List[str]) -> NoReturn:
     args = parse_args(argv)
     if args.platform:
-        success = run_specified_checks(args.platform, args.extra_checks)
+        success = run_checks_specific_platform(
+            args.platform, args.extra_checks
+        )
     else:
-        success = run_all_checks(args.extra_checks)
+        success = run_checks_all_platforms(args.extra_checks)
     sys.exit(0 if success else 1)
 
 

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -1844,7 +1844,7 @@ class TestGDPKernelDriver(_CheckTestBase):
         assert not success
 
     def test_loaded_and_installed(self, capsys):
-        """Test where vfio-pci is loaded and igb_uio is installed."""
+        """Test where vfio-pci is loaded and igb_uio is installed but not loaded."""
         success, output = self.perform_check(
             capsys,
             cmd_effects=[
@@ -1867,7 +1867,7 @@ class TestGDPKernelDriver(_CheckTestBase):
         assert success
 
     def test_installed_and_builtin(self, capsys):
-        """Test where vfio-pci is installed and igb_uio is builtin."""
+        """Test where vfio-pci is installed but not loaded and igb_uio is builtin."""
         success, output = self.perform_check(
             capsys,
             cmd_effects=[

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -2072,7 +2072,7 @@ Bus info          Device      Class      Description
             )
         assert output == textwrap.dedent(
             f"""\
-            FAIL -- IOMMU (no PCI network devices found)
+            WARN -- IOMMU (no PCI network devices found)
             """
         )
         assert not success
@@ -2114,7 +2114,7 @@ Bus info          Device      Class      Description
             )
         assert output == textwrap.dedent(
             f"""\
-            FAIL -- IOMMU
+            WARN -- IOMMU
                     The kernel module vfio-pci cannot be used, as IOMMU is not enabled.
                     IOMMU is recommended for security when using the vfio-pci kernel driver.
             """
@@ -2230,36 +2230,6 @@ pci@0000:00:01.0  device2     network    Ethernet interface
         assert output == textwrap.dedent(
             f"""\
             INFO -- IOMMU (vfio-pci driver unavailable)
-            """
-        )
-        assert success
-
-    def test_fail_igb_uio_enabled(self, capsys):
-        """
-        Test a failure in the IOMMU check when igb_uio is enabled (should just
-        result in INFO result).
-        """
-        lshw_output = """\
-Bus info          Device      Class      Description
-====================================================
-        """
-        iommu_devices = [
-            "0000:00:00.0",
-            "0000:00:01.0",
-            "0000:00:02.0",
-            "0000:00:1f.0",
-            "0000:00:1f.2",
-            "0000:00:1f.3",
-        ]
-        with mock.patch("glob.glob", return_value=iommu_devices):
-            success, output = self.perform_check(
-                capsys,
-                cmd_effects=["", None, "", None, lshw_output],
-                read_effects="N",
-            )
-        assert output == textwrap.dedent(
-            f"""\
-            INFO -- IOMMU (no PCI network devices found)
             """
         )
         assert success

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -224,22 +224,8 @@ xrd-vrouter checks
 -----------------------
 Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size
 
-==============================
-Extra checks
-==============================
-
-docker checks
------------------------
-Checks: Docker client, Docker daemon, Docker supports d_type
-
-xr-compose checks
------------------------
-Checks: docker-compose, PyYAML, Bridge iptables
-
 ==================================================================
 XR platforms supported: xrd-control-plane, xrd-vrouter
-------------------------------------------------------------------
-Extra checks passed: docker, xr-compose
 ==================================================================
 """
         assert output == cli_output
@@ -279,7 +265,7 @@ Host environment set up correctly for xrd-vrouter
         assert output == cli_output
         assert exit_code == 0
 
-    def test_extra_check_docker(self, capsys):
+    def test_extra_check_docker_plat(self, capsys):
         """Test running host-check with the docker extra check."""
         exit_code, output = self.run_host_check(
             capsys, ["-p", "xrd-control-plane", "-e", "docker"]
@@ -307,7 +293,7 @@ Extra checks passed: docker
         assert output == cli_output
         assert exit_code == 0
 
-    def test_extra_check_xr_compose(self, capsys):
+    def test_extra_check_xr_compose_plat(self, capsys):
         """Test running host-check with the xr-compose extra check."""
         exit_code, output = self.run_host_check(
             capsys, ["-p", "xrd-control-plane", "-e", "xr-compose"]
@@ -335,7 +321,7 @@ Extra checks passed: xr-compose
         assert output == cli_output
         assert exit_code == 0
 
-    def test_all_extra_checks(self, capsys):
+    def test_all_extra_checks_plat(self, capsys):
         """Test running host-check with all extra checks."""
         exit_code, output = self.run_host_check(
             capsys, ["-p", "xrd-control-plane", "-e", "xr-compose", "docker"]
@@ -360,6 +346,123 @@ Checks: docker-compose, PyYAML, Bridge iptables
 
 ==================================================================
 Host environment set up correctly for xrd-control-plane
+------------------------------------------------------------------
+Extra checks passed: docker, xr-compose
+==================================================================
+"""
+        assert output == cli_output
+        assert exit_code == 0
+
+    def test_extra_check_docker(self, capsys):
+        """Test running host-check with the docker extra check."""
+        exit_code, output = self.run_host_check(capsys, ["-e", "docker"])
+        cli_output = f"""\
+==============================
+Platform checks
+==============================
+
+base checks
+-----------------------
+Checks: {BASE_CHECKS_STR}
+
+xrd-control-plane checks
+-----------------------
+Checks: RAM
+
+xrd-vrouter checks
+-----------------------
+Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size
+
+==============================
+Extra checks
+==============================
+
+docker checks
+-----------------------
+Checks: Docker client, Docker daemon, Docker supports d_type
+
+==================================================================
+XR platforms supported: xrd-control-plane, xrd-vrouter
+------------------------------------------------------------------
+Extra checks passed: docker
+==================================================================
+"""
+        assert output == cli_output
+        assert exit_code == 0
+
+    def test_extra_check_xr_compose(self, capsys):
+        """Test running host-check with the xr-compose extra check."""
+        exit_code, output = self.run_host_check(capsys, ["-e", "xr-compose"])
+        cli_output = f"""\
+==============================
+Platform checks
+==============================
+
+base checks
+-----------------------
+Checks: {BASE_CHECKS_STR}
+
+xrd-control-plane checks
+-----------------------
+Checks: RAM
+
+xrd-vrouter checks
+-----------------------
+Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size
+
+==============================
+Extra checks
+==============================
+
+xr-compose checks
+-----------------------
+Checks: docker-compose, PyYAML, Bridge iptables
+
+==================================================================
+XR platforms supported: xrd-control-plane, xrd-vrouter
+------------------------------------------------------------------
+Extra checks passed: xr-compose
+==================================================================
+"""
+        assert output == cli_output
+        assert exit_code == 0
+
+    def test_all_extra_checks(self, capsys):
+        """Test running host-check with all extra checks."""
+        exit_code, output = self.run_host_check(
+            capsys, ["-e", "xr-compose", "docker"]
+        )
+        cli_output = f"""\
+==============================
+Platform checks
+==============================
+
+base checks
+-----------------------
+Checks: {BASE_CHECKS_STR}
+
+xrd-control-plane checks
+-----------------------
+Checks: RAM
+
+xrd-vrouter checks
+-----------------------
+Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size
+
+==============================
+Extra checks
+==============================
+
+docker checks
+-----------------------
+Checks: Docker client, Docker daemon, Docker supports d_type
+
+xr-compose checks
+-----------------------
+Checks: docker-compose, PyYAML, Bridge iptables
+
+==================================================================
+XR platforms supported: xrd-control-plane, xrd-vrouter
 ------------------------------------------------------------------
 Extra checks passed: docker, xr-compose
 ==================================================================
@@ -409,22 +512,8 @@ xrd-vrouter checks
 -----------------------
 Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size
 
-==============================
-Extra checks
-==============================
-
-docker checks
------------------------
-Checks: Docker client, Docker daemon, Docker supports d_type
-
-xr-compose checks
------------------------
-Checks: docker-compose, PyYAML, Bridge iptables
-
 ==================================================================
 !! Host NOT set up correctly for any XR platforms !!
-------------------------------------------------------------------
-Extra checks passed: docker, xr-compose
 ==================================================================
 """
         assert output == cli_output
@@ -452,23 +541,9 @@ xrd-vrouter checks
 -----------------------
 Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size
 
-==============================
-Extra checks
-==============================
-
-docker checks
------------------------
-Checks: Docker client, Docker daemon, Docker supports d_type
-
-xr-compose checks
------------------------
-Checks: docker-compose, PyYAML, Bridge iptables
-
 ==================================================================
 XR platforms supported: xrd-control-plane
 XR platforms NOT supported: xrd-vrouter
-------------------------------------------------------------------
-Extra checks passed: docker, xr-compose
 ==================================================================
 """
         assert output == cli_output
@@ -477,7 +552,7 @@ Extra checks passed: docker, xr-compose
     def test_extra_check_not_supported(self, capsys):
         """Test an extra check not being supported when host-check is run without arguments."""
         exit_code, output = self.run_host_check(
-            capsys, [], failing_checks=["PyYAML"]
+            capsys, ["-e", "docker", "xr-compose"], failing_checks=["PyYAML"]
         )
         cli_output = f"""\
 ==============================
@@ -552,12 +627,6 @@ Extra checks failed: xr-compose
 """
         assert output == cli_output
         assert exit_code == 1
-
-    def test_missing_plat_arg(self, capsys):
-        """Test running host-check with the platform argument missing."""
-        exit_code, output = self.run_host_check(capsys, ["-e", "docker"])
-        assert output == ""
-        assert exit_code == 2
 
     def test_unrecognized_arg(self, capsys):
         """Test running host-check with an unrecognized argument."""


### PR DESCRIPTION
Updates to host-check, including:
- Don't run extra checks by default
- Make igb_uio supported, failing if no PCI driver is loaded, and warning if there's a PCI driver that's installed but not loaded
- Only check if IOMMU is enabled when vfio-pci is being used
- Handle the case where IOMMU is unconfigurable

Plus corresponding updates to test_host_check.py