### PR TITLE
Host check Timeout error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ It is planned to support 7.8.1 when this version is released.
 
 ### v1.0.4 (2022-11-30)
 
-- `host-check` script now gives a different error when a command times out
+- Indicate when a command times out in the `host-check` script.
 
 ### v1.0.3 (2022-10-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The v1 release supports Cisco IOS-XR release version 7.7.1.
 It is planned to support 7.8.1 when this version is released.
 
 
+### v1.0.4 (2022-11-30)
+
+- `host-check` script now gives a different error when a command times out
+
 ### v1.0.3 (2022-10-26)
 
 - To check if AppArmor is enabled, `host-check` script now looks at `"/sys/kernel/security/apparmor/profiles"` instead of `"/sys/module/apparmor/parameters/enabled"`.

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -126,6 +126,22 @@ def purple(string: str) -> str:
 _CMD = Union[str, List[str]]
 
 
+class CmdTimeoutError(Exception):
+    """
+    Error to "replace" subprocess.TimeoutExpired
+    This is so that the error is treated differently from all the other errors
+    in subprocess.SubprocessError
+
+    """
+
+    def __init__(self, cmd: _CMD):
+        super().__init__()
+        self.cmd = cmd if type(cmd) is str else " ".join(cmd)
+
+    def __str__(self) -> str:
+        return f"Timed out while executing command: {self.cmd}"
+
+
 def run_cmd(
     cmd: _CMD,
     *,
@@ -160,8 +176,10 @@ def run_cmd(
         check=check,
     )
     kwargs = {**default_kwargs, **kwargs}
-
-    ret = subprocess.run(cmd, **kwargs)
+    try:
+        ret = subprocess.run(cmd, **kwargs)
+    except subprocess.TimeoutExpired as exc:
+        raise CmdTimeoutError(exc.cmd) from exc
     return ret.stdout, ret.stderr
 
 
@@ -1297,6 +1315,9 @@ def perform_checks(checks: List[Check]) -> bool:
                 else:
                     status = CheckState.SUCCESS
                     msg = None
+            except CmdTimeoutError as e:
+                status = CheckState.WARNING
+                msg = f"Unexpected error: {e}"
             except Exception as e:
                 status = CheckState.FAILED
                 msg = f"Unexpected error: {e}"

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -128,9 +128,8 @@ _CMD = Union[str, List[str]]
 
 class CmdTimeoutError(Exception):
     """
-    Error to "replace" subprocess.TimeoutExpired
-    This is so that the error is treated differently from all the other errors
-    in subprocess.SubprocessError
+    This is so that command timeouts can be handled separately to other
+    subprocess.SubprocessError errors.
 
     """
 

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -808,6 +808,20 @@ class TestCPUCores(_CheckTestBase):
         )
         assert not success
 
+    def test_timeout_error(self, capsys):
+        """Test timeout error being raised."""
+        success, output = self.perform_check(
+            capsys,
+            cmd_effects=subprocess.TimeoutExpired(cmd=self.cmds, timeout=5),
+        )
+        assert output == textwrap.dedent(
+            f"""\
+            WARN -- CPU cores
+                    Unexpected error: Timed out while executing command: {" ".join(self.cmds)}
+            """
+        )
+        assert not success
+
 
 class TestKernelVersion(_CheckTestBase):
     """Tests for the kernel version check."""
@@ -1127,6 +1141,20 @@ class TestSystemdMounts(_CheckTestBase):
             """\
             FAIL -- systemd mounts
                     Unexpected error: test exception
+            """
+        )
+        assert not success
+
+    def test_timeout_error(self, capsys):
+        """Test timeout error being raised."""
+        success, output = self.perform_check(
+            capsys,
+            cmd_effects=subprocess.TimeoutExpired(cmd=self.cmds, timeout=5),
+        )
+        assert output == textwrap.dedent(
+            f"""\
+            WARN -- systemd mounts
+                    Unexpected error: Timed out while executing command: {" ".join(self.cmds)}
             """
         )
         assert not success


### PR DESCRIPTION
`host-check` script now gives a different error when a command times out