### PR TITLE
-- support in launch-xrd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@
 
 The v1 release supports Cisco IOS-XR release versions 7.7.1 and 7.8.1.
 
+### v1.1.2 (2022-01-06)
+
+- In the `launch-xrd` script the mechanism for passing extra args to the container manager has been updated. Args after '--' separator will be passed to the container manager as well. To clarify, this is in addition to the existing mechanism of unrecognised arguments (before the '--' separator) being passed to the container manager. This will facilitate passing args common to the script and the container manager.
+
+
 ### v1.1.1 (2022-12-05)
 
 - In the `launch-xrd` script the mechanism for passing extra args to the container manager has changed. The `--args` argument is no longer required - every unrecognised argument will be passed to the container manager. The container image must now be passed as the last argument to the script. The `--args` method is still supported for backwards compatibility, but will be removed in the future.
+
 
 ### v1.1.0 (2022-12-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 The v1 release supports Cisco IOS-XR release versions 7.7.1 and 7.8.1.
 
-### v1.1.2 (2022-01-06)
+### v1.1.2 (2023-01-06)
 
 - In the `launch-xrd` script the mechanism for passing extra args to the container manager has been updated. Args after '--' separator will be passed to the container manager as well. To clarify, this is in addition to the existing mechanism of unrecognised arguments (before the '--' separator) being passed to the container manager. This will facilitate passing args common to the script and the container manager.
 

--- a/scripts/launch-xrd
+++ b/scripts/launch-xrd
@@ -72,9 +72,10 @@ Optional arguments:
   --boot-log-level LEVEL        Control the level at which boot logging starts
                                 being printed to the console, one of: ERROR,
                                 WARNING (default), INFO, DEBUG
-  <arg1> <arg2>                 Extra arguments to pass to '<ctr_mgr> run'.
-                                'launch-xrd <arg1> IMG' would become
-                                '<ctr_mgr> run <arg1> IMG'
+  [--] <arg1> <arg2>            Extra arguments to pass to '<ctr_mgr> run'.
+                                'launch-xrd <arg1> IMG' or 'launch-xrd --
+                                <arg1> IMG' would become '<ctr_mgr> run <arg1>
+                                IMG'
 
 XRd Control Plane arguments:
   IF_TYPE := { linux }          Interface type
@@ -244,10 +245,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         -- )
             shift
-            if [[ ${#CTR_MGR_ARGS[@]} -ne 0 ]]; then
-                echo "When using --, use container manager args after it. These args are inavlid for the script ${CTR_MGR_ARGS[*]}" >&2
-                bad_usage
-            fi
             CTR_MGR_ARGS+=("$@")
             shift $#
             ;;

--- a/scripts/launch-xrd
+++ b/scripts/launch-xrd
@@ -243,12 +243,18 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -- )
-           shift
-           ;;
+            shift
+            if [[ ${#CTR_MGR_ARGS[@]} -ne 0 ]]; then
+                echo "When using --, use container manager args after it. These args are inavlid for the script ${CTR_MGR_ARGS[*]}" >&2
+                bad_usage
+            fi
+            CTR_MGR_ARGS+=("$@")
+            shift $#
+            ;;
         *)
-           CTR_MGR_ARGS+=("$1")
-           shift
-           ;;
+            CTR_MGR_ARGS+=("$1")
+            shift
+            ;;
     esac
 done
 

--- a/scripts/launch-xrd
+++ b/scripts/launch-xrd
@@ -245,7 +245,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         -- )
             shift
-            if [[ $# -eq 0 ]]; then
+            if [[ $# == 0 ]]; then
                 echo "Invalid syntax: No args after --." >&2
                 bad_usage
             fi

--- a/scripts/launch-xrd
+++ b/scripts/launch-xrd
@@ -73,9 +73,11 @@ Optional arguments:
                                 being printed to the console, one of: ERROR,
                                 WARNING (default), INFO, DEBUG
   [--] <arg1> <arg2>            Extra arguments to pass to '<ctr_mgr> run'.
-                                'launch-xrd <arg1> IMG' or 'launch-xrd --
-                                <arg1> IMG' would become '<ctr_mgr> run <arg1>
-                                IMG'
+                                All unrecognised args and all args after '--'
+                                separator will be passed to the container
+                                manager 'launch-xrd <arg1> IMG' or 'launch-xrd
+                                -- <arg1> IMG' would become '<ctr_mgr> run
+                                <arg1> IMG'
 
 XRd Control Plane arguments:
   IF_TYPE := { linux }          Interface type

--- a/scripts/launch-xrd
+++ b/scripts/launch-xrd
@@ -245,8 +245,12 @@ while [[ $# -gt 0 ]]; do
             ;;
         -- )
             shift
+            if [[ $# -eq 0 ]]; then
+                echo "Invalid syntax: No args after --." >&2
+                bad_usage
+            fi
             CTR_MGR_ARGS+=("$@")
-            shift $#
+            break
             ;;
         *)
             CTR_MGR_ARGS+=("$1")

--- a/scripts/launch-xrd
+++ b/scripts/launch-xrd
@@ -75,7 +75,7 @@ Optional arguments:
   [--] <arg1> <arg2>            Extra arguments to pass to '<ctr_mgr> run'.
                                 All unrecognised args and all args after '--'
                                 separator will be passed to the container
-                                manager 'launch-xrd <arg1> IMG' or 'launch-xrd
+                                manager. 'launch-xrd <arg1> IMG' or 'launch-xrd
                                 -- <arg1> IMG' would become '<ctr_mgr> run
                                 <arg1> IMG'
 

--- a/scripts/launch-xrd
+++ b/scripts/launch-xrd
@@ -246,7 +246,7 @@ while [[ $# -gt 0 ]]; do
         -- )
             shift
             if [[ $# == 0 ]]; then
-                echo "Invalid syntax: No args after --." >&2
+                echo "Error: Expected at least one arg after the '--' separator." >&2
                 bad_usage
             fi
             CTR_MGR_ARGS+=("$@")


### PR DESCRIPTION
With this change all args after -- are passed directly to the container manager.

```
> scripts/launch-xrd -n -p xrd-vrouter --privileged -- foo bar -p xrd-control-plane abcd 
docker run -it --rm --privileged --env XR_MGMT_INTERFACES=linux:eth0,chksum foo bar -p xrd-control-plane abcd

> scripts/launch-xrd -n -p xrd-vrouter -e my_config.cfg --privileged -- foo bar -p xrd-control-plane -e MY_ENV=1 IMG
docker run -it --rm --privileged --mount type=bind,source=/nobackup/yashaga/xrd-tools/my_config.cfg,target=/etc/xrd/every-boot.cfg --env XR_EVERY_BOOT_CONFIG=/etc/xrd/every-boot.cfg --env XR_MGMT_INTERFACES=linux:eth0,chksum foo bar -p xrd-control-plane -e MY_ENV=1 IMG
```