### PR TITLE
XR-compose: Read input file to check container privilege

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 The v1 release supports Cisco IOS-XR release versions 7.7.1 and 7.8.1.
 
+### v1.1.3 (2023-01-26)
+
+- `xr-compose` script will now respect the privilege status of a container in the input file.
+
+
 ### v1.1.2 (2023-01-06)
 
 - In the `launch-xrd` script the mechanism for passing extra args to the container manager has been updated. Args after '--' separator will be passed to the container manager as well. To clarify, this is in addition to the existing mechanism of unrecognised arguments (before the '--' separator) being passed to the container manager. This will facilitate passing args common to the script and the container manager.

--- a/scripts/xr-compose
+++ b/scripts/xr-compose
@@ -1934,7 +1934,10 @@ def parse_input_args(argv: List[str]) -> argparse.Namespace:
         "-d", "--debug", action="store_true", help="Enable debug output"
     )
     parser.add_argument(
-        "--privileged", action="store_true", help="Launch in privileged mode"
+        "--privileged",
+        action="store_true",
+        help="Launch in privileged mode. Privilege status of a container in "
+        "the input yaml wold overwrite this",
     )
 
     return parser.parse_args(argv)

--- a/scripts/xr-compose
+++ b/scripts/xr-compose
@@ -1596,7 +1596,12 @@ class XRCompose:
         )
         service_yaml = self.yaml["services"][service.service_name]
 
-        if self.privileged:
+        container_priv = (
+            service_yaml["privileged"]
+            if "privileged" in service_yaml.keys()
+            else self.privileged
+        )
+        if container_priv:
             service_yaml["privileged"] = True
         else:
             service_yaml["cap_drop"] = ["all"]

--- a/scripts/xr-compose
+++ b/scripts/xr-compose
@@ -1596,12 +1596,7 @@ class XRCompose:
         )
         service_yaml = self.yaml["services"][service.service_name]
 
-        container_priv = (
-            service_yaml["privileged"]
-            if "privileged" in service_yaml.keys()
-            else self.privileged
-        )
-        if container_priv:
+        if service_yaml.get("privileged", self.privileged):
             service_yaml["privileged"] = True
         else:
             service_yaml["cap_drop"] = ["all"]


### PR DESCRIPTION
`xr-compose` to read the input file to check the privilege status of a container. If the field isn't present in the input yaml, CLI arg would be used.