### PR TITLE
launch:xrd: Don't try to pull an image, if dry-run is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 The v1 release supports Cisco IOS-XR release versions 7.7.1 and 7.8.1.
 
+### v1.1.7 (2023-02-24)
+
+- `launch-xrd` to output a message asking the user to specify the platform when specifying dry-run on a non-loaded image, instead of trying to pull the image.
+
+
 ### v1.1.6 (2023-02-22)
 
 - Add checks for correct socket kernel parameters to `host-check`.

--- a/scripts/launch-xrd
+++ b/scripts/launch-xrd
@@ -134,18 +134,11 @@ _runcmd() {
 # Pulls an image if not loaded already. Return code 1 if image is unavilable
 #   Arg 1: image name
 _pull_image() {
-    if [[ $DRY_RUN == 1 ]]; then
-        echo "The image $1 has not been loaded in the local $CONTAINER_MGR registry" >&2
-        echo "Platform must be specified for dry-run when the image isn't loaded" >&2
-        echo "Use '--platform' argument." >&2
+    echo "Specified image is not loaded, attempting to pull..."
+    if ! "$CONTAINER_EXE" pull "$1" || ! "$CONTAINER_EXE" inspect "$1" &>/dev/null; then
+        echo "Unrecognised image '$1' - should be either an image loaded " \
+            "in the local $CONTAINER_MGR registry or an image that can be pulled." >&2
         return 1
-    else
-        echo "Specified image is not loaded, attempting to pull..."
-        if ! "$CONTAINER_EXE" pull "$1" || ! "$CONTAINER_EXE" inspect "$1" &>/dev/null; then
-            echo "Unrecognised image '$1' - should be either an image loaded " \
-                "in the local $CONTAINER_MGR registry or an image that can be pulled." >&2
-            return 1
-        fi
     fi
 }
 
@@ -313,7 +306,14 @@ fi
 # Obtain the platform from the chosen image.
 if [[ ! $PLATFORM ]]; then
     if ! $CONTAINER_EXE inspect "$IMAGE" &>/dev/null; then
-        _pull_image "$IMAGE" || exit 1
+        if [[ $DRY_RUN == 1 ]]; then
+            echo "The image $1 is not loaded in the local $CONTAINER_MGR registry." >&2
+            echo "Platform must be specified for dry-run when the image isn't loaded." >&2
+            echo "Use '--platform' argument." >&2
+            exit 1
+        else
+            _pull_image "$IMAGE" || exit 1
+        fi
     fi
     PLATFORM="$(_get_platform "$IMAGE")" || exit 1
 fi

--- a/scripts/launch-xrd
+++ b/scripts/launch-xrd
@@ -134,10 +134,18 @@ _runcmd() {
 # Pulls an image if not loaded already. Return code 1 if image is unavilable
 #   Arg 1: image name
 _pull_image() {
-    if ! "$CONTAINER_EXE" pull "$1" || ! "$CONTAINER_EXE" inspect "$1" &>/dev/null; then
-        echo "Unrecognised image '$1' - should be either an image loaded " \
-            "in the local $CONTAINER_MGR registry or an image that can be pulled." >&2
+    if [[ $DRY_RUN == 1 ]]; then
+        echo "The image $1 has not been loaded in the local $CONTAINER_MGR registry" >&2
+        echo "Platform must be specified for dry-run when the image isn't loaded" >&2
+        echo "Use '--platform' argument." >&2
         return 1
+    else
+        echo "Specified image is not loaded, attempting to pull..."
+        if ! "$CONTAINER_EXE" pull "$1" || ! "$CONTAINER_EXE" inspect "$1" &>/dev/null; then
+            echo "Unrecognised image '$1' - should be either an image loaded " \
+                "in the local $CONTAINER_MGR registry or an image that can be pulled." >&2
+            return 1
+        fi
     fi
 }
 
@@ -305,7 +313,6 @@ fi
 # Obtain the platform from the chosen image.
 if [[ ! $PLATFORM ]]; then
     if ! $CONTAINER_EXE inspect "$IMAGE" &>/dev/null; then
-        echo "Specified image is not loaded, attempting to pull..."
         _pull_image "$IMAGE" || exit 1
     fi
     PLATFORM="$(_get_platform "$IMAGE")" || exit 1


### PR DESCRIPTION
`launch-xrd` to output a message asking the user to specify the platform when specifying dry-run on a non-loaded image.
The existing behaviour was to try pulling the image. Now it won't try pulling.

```
> scripts/launch-xrd --ctr-client podman-remote3.4 containers.cisco.com/xrd/xrd-vrouter 
Specified image is not loaded, attempting to pull...
Trying to pull containers.cisco.com/xrd/xrd-control-plane:latest...
[...]
> scripts/launch-xrd containers.cisco.com/xrd/xrd-vrouter -n
The image containers.cisco.com/xrd/xrd-vrouter has not been loaded in the local docker registry
Platform must be specified for dry-run when the image isn't loaded
Use '--platform' argument.
> scripts/launch-xrd containers.cisco.com/xrd/xrd-vrouter --platform xrd-vrouter --privileged -n
docker run -it --rm --privileged --env XR_MGMT_INTERFACES=linux:eth0,chksum containers.cisco.com/xrd/xrd-vrouter
```