### PR TITLE
Add if cgroup mounts exists on the host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 The v1 release supports Cisco IOS-XR release versions 7.7.1 and 7.8.1.
 
+### v1.1.8 (2023-03-08)
+
+- Add a check in the `host-check` script to verify if the host has required cgroup mounts.
+
 ### v1.1.7 (2023-02-24)
 
 - `launch-xrd` to output a message asking the user to specify the platform when specifying dry-run on a non-loaded image, instead of trying to pull the image.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The v1 release supports Cisco IOS-XR release versions 7.7.1 and 7.8.1.
 
 - Add a check in the `host-check` script to verify if the host has required cgroup mounts.
 
+
 ### v1.1.7 (2023-02-24)
 
 - `launch-xrd` to output a message asking the user to specify the platform when specifying dry-run on a non-loaded image, instead of trying to pull the image.

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -461,15 +461,12 @@ def check_cgroups() -> CheckFuncReturn:
             f"These cgroup mounts do not exist on the host: {', '.join(not_exist_mounts)}."
             "\nThese mounts are required to run XRd."
         )
-        fail_msg += (
-            (
+        if "systemd" in not_exist_mounts:
+            fail_msg += (
                 "\nIf your distro doesn't use systemd, manually add the systemd cgroup mount with:"
                 "\n    sudo mkdir /sys/fs/cgroup/systemd"
                 "\n    sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd"
             )
-            if "systemd" in not_exist_mounts
-            else ""
-        )
         return CheckState.FAILED, fail_msg
     return CheckState.SUCCESS, f"v{version}"
 

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -72,6 +72,8 @@ MIN_MEMLOCK_GB = 2
 REGULAR_STYLE = 0
 BOLD_STYLE = 1
 
+REQUIRED_CGROUP_MOUNTS = ["systemd", "memory", "pids", "cpu", "cpuset"]
+
 DASHED_LINE = (
     "------------------------------------------------------------------"
 )
@@ -448,6 +450,27 @@ def check_cgroups() -> CheckFuncReturn:
             "Cgroups v2 is in use - this is not supported for production environments.",
         )
     assert version == 1
+
+    not_exist_mounts = [
+        cgrp_dir
+        for cgrp_dir in REQUIRED_CGROUP_MOUNTS
+        if not _mount_exists(f"/sys/fs/cgroup/{cgrp_dir}", type_="cgroup")
+    ]
+    if not_exist_mounts:
+        fail_msg = (
+            f"These cgroup mounts do not exist on the host: {', '.join(not_exist_mounts)}."
+            "\nThese mounts are required to run XRd."
+        )
+        fail_msg += (
+            (
+                "\nTo add a systemd mount, run:"
+                "\n    sudo mkdir /sys/fs/cgroup/systemd"
+                "\n    sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd"
+            )
+            if "systemd" in not_exist_mounts
+            else ""
+        )
+        return CheckState.FAILED, fail_msg
     return CheckState.SUCCESS, f"v{version}"
 
 

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -463,7 +463,7 @@ def check_cgroups() -> CheckFuncReturn:
         )
         fail_msg += (
             (
-                "\nTo add a systemd mount, run:"
+                "\nIf your distro doesn't use systemd, manually add the systemd cgroup mount with:"
                 "\n    sudo mkdir /sys/fs/cgroup/systemd"
                 "\n    sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd"
             )

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -1010,10 +1010,6 @@ class TestCgroups(_CheckTestBase):
         "findmnt /sys/fs/cgroup/cpu -t cgroup",
         "findmnt /sys/fs/cgroup/cpuset -t cgroup",
     ]
-    cmds += [
-        f"findmnt /sys/fs/cgroup/{cgrp_dir} -t cgroup"
-        for cgrp_dir in host_check.REQUIRED_CGROUP_MOUNTS
-    ]
 
     @staticmethod
     @pytest.fixture(scope="class", autouse=True)
@@ -1104,7 +1100,7 @@ class TestCgroups(_CheckTestBase):
             FAIL -- Cgroups
                     These cgroup mounts do not exist on the host: systemd.
                     These mounts are required to run XRd.
-                    To add a systemd mount, run:
+                    If your distro doesn't use systemd, manually add the systemd cgroup mount with:
                         sudo mkdir /sys/fs/cgroup/systemd
                         sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
             """
@@ -1153,7 +1149,7 @@ class TestCgroups(_CheckTestBase):
             FAIL -- Cgroups
                     These cgroup mounts do not exist on the host: systemd, cpu.
                     These mounts are required to run XRd.
-                    To add a systemd mount, run:
+                    If your distro doesn't use systemd, manually add the systemd cgroup mount with:
                         sudo mkdir /sys/fs/cgroup/systemd
                         sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
             """

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -1004,6 +1004,15 @@ class TestCgroups(_CheckTestBase):
     cmds = [
         "findmnt /sys/fs/cgroup -t cgroup2",
         "findmnt /sys/fs/cgroup/memory -t cgroup",
+        "findmnt /sys/fs/cgroup/systemd -t cgroup",
+        "findmnt /sys/fs/cgroup/memory -t cgroup",
+        "findmnt /sys/fs/cgroup/pids -t cgroup",
+        "findmnt /sys/fs/cgroup/cpu -t cgroup",
+        "findmnt /sys/fs/cgroup/cpuset -t cgroup",
+    ]
+    cmds += [
+        f"findmnt /sys/fs/cgroup/{cgrp_dir} -t cgroup"
+        for cgrp_dir in host_check.REQUIRED_CGROUP_MOUNTS
     ]
 
     @staticmethod
@@ -1016,7 +1025,15 @@ class TestCgroups(_CheckTestBase):
         """Test the cgroups v1 success case."""
         success, output = self.perform_check(
             capsys,
-            cmd_effects=[mock.Mock(returncode=1), mock.Mock(returncode=0)],
+            cmd_effects=[
+                mock.Mock(returncode=1),
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=0),
+            ],
         )
         assert output == textwrap.dedent(
             """\
@@ -1064,6 +1081,81 @@ class TestCgroups(_CheckTestBase):
             FAIL -- Cgroups
                     Error trying to determine the cgroups version - /sys/fs/cgroup is expected to
                     contain cgroup v1 mounts.
+            """
+        )
+        assert not success
+
+    def test_systemd_mount_error(self, capsys):
+        """Test case where systemd mount isn't present."""
+        success, output = self.perform_check(
+            capsys,
+            cmd_effects=[
+                mock.Mock(returncode=1),
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=1),  # /sys/fs/cgroup/systemd
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=0),
+            ],
+        )
+        assert output == textwrap.dedent(
+            """\
+            FAIL -- Cgroups
+                    These cgroup mounts do not exist on the host: systemd.
+                    These mounts are required to run XRd.
+                    To add a systemd mount, run:
+                        sudo mkdir /sys/fs/cgroup/systemd
+                        sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
+            """
+        )
+        assert not success
+
+    def test_pids_mount_error(self, capsys):
+        """Test case where systemd mount isn't present."""
+        success, output = self.perform_check(
+            capsys,
+            cmd_effects=[
+                mock.Mock(returncode=1),
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=1),  # /sys/fs/cgroup/pids
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=0),
+            ],
+        )
+        assert output == textwrap.dedent(
+            """\
+            FAIL -- Cgroups
+                    These cgroup mounts do not exist on the host: pids.
+                    These mounts are required to run XRd.
+            """
+        )
+        assert not success
+
+    def test_systemd_cpu_mount_error(self, capsys):
+        """Test case where systemd mount isn't present."""
+        success, output = self.perform_check(
+            capsys,
+            cmd_effects=[
+                mock.Mock(returncode=1),
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=1),  # /sys/fs/cgroup/systemd
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=0),
+                mock.Mock(returncode=1),  # /sys/fs/cgroup/cpu
+                mock.Mock(returncode=0),
+            ],
+        )
+        assert output == textwrap.dedent(
+            """\
+            FAIL -- Cgroups
+                    These cgroup mounts do not exist on the host: systemd, cpu.
+                    These mounts are required to run XRd.
+                    To add a systemd mount, run:
+                        sudo mkdir /sys/fs/cgroup/systemd
+                        sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
             """
         )
         assert not success


### PR DESCRIPTION
The cgroup mounts used by the container needs to exist on the host. If they don't exist, the container manager doesnt clear the stale cgroup rules on stopping the container.

Added a check in `host-check` script to verify the mounts exist.

Manual Tests:
- On Alpine distro (without systemd):
   - Ran `host-check` and it fails with the expected error
   - On running the suggested command, the cgroup test passed
   - On unmounting the memory cgroup, the test failed with the expected error
- On Ubuntu:
   - Test passed

Notes:
- If a command is run multiple times in a test, you have to specify it multiple times in `cmd_effects` and `cmd` variable too. Are we okay with that?
- Are the tests I added too much, should I combine/remove any of them?