### PR TITLE
launch-xrd: Quote CONTAINER_EXE

### DIFF
--- a/scripts/launch-xrd
+++ b/scripts/launch-xrd
@@ -146,7 +146,7 @@ _pull_image() {
 #   Arg 1: image name
 _get_platform() {
     local platform
-    if ! platform="$($CONTAINER_EXE inspect "$1" \
+    if ! platform="$("$CONTAINER_EXE" inspect "$1" \
         --format='{{index .Config.Labels "com.cisco.ios-xr.platform"}}' \
         2>/dev/null)"; then
         # This should never be hit.
@@ -305,7 +305,7 @@ fi
 
 # Obtain the platform from the chosen image.
 if [[ ! $PLATFORM ]]; then
-    if ! $CONTAINER_EXE inspect "$IMAGE" &>/dev/null; then
+    if ! "$CONTAINER_EXE" inspect "$IMAGE" &>/dev/null; then
         if [[ $DRY_RUN == 1 ]]; then
             echo "The image $1 is not loaded in the local $CONTAINER_MGR registry." >&2
             echo "Platform must be specified for dry-run when the image isn't loaded." >&2


### PR DESCRIPTION
The `CONTAINER_EXE` variable was unquoted in two locations meaning that bash expansion and splitting will be performed. This change quotes the variable.

Before
```
 > mkdir my\ dir
 > ln -s /bin/docker my\ dir/docker
 > launch-xrd --ctr-client "my dir/docker" containers.cisco.com/xrd/xrd-control-plane
Specified image is not loaded, attempting to pull...
Using default tag: latest
latest: Pulling from xrd/xrd-control-plane
Digest: sha256:f3ee6e5df13aeb191834d47f288626b2659fb5199ce28b2ea6203dbad9dfae9e
Status: Image is up to date for containers.cisco.com/xrd/xrd-control-plane:latest
containers.cisco.com/xrd/xrd-control-plane:latest
Image containers.cisco.com/xrd/xrd-control-plane cannot be found in the local docker registry.
```
After
```
 > ./scripts/launch-xrd --ctr-client "my dir/docker" containers.cisco.com/xrd/xrd-control-plane
Specified image is not loaded, attempting to pull...
Using default tag: latest
latest: Pulling from xrd/xrd-control-plane
96360653832c: Pull complete
Digest: sha256:7147d2086ddad87e86cffcdd2c7381c3f7dd40527286f139090de8c48e4e229a
Status: Downloaded newer image for containers.cisco.com/xrd/xrd-control-plane:latest
containers.cisco.com/xrd/xrd-control-plane:latest
systemd 244.5+ running in system mode. (+PAM +AUDIT +SELINUX +IMA -APPARMOR -SMACK +SYSVINIT +UTMP -LIBCRYPTSETUP -GCRYPT -GNUTLS +ACL +XZ -LZ4 -SECCOMP +BLKID -ELFUTILS +KMOD -IDN2 -IDN -PCRE2 default-hierarchy=hybrid)
Detected virtualization docker.
Detected architecture x86-64.

Welcome to Linux Distro for XR 11.1.2 (dunfell)!

Set hostname to <aca7a3effcd2>.
Initializing machine ID from random generator.
[  OK  ] Created slice User and Session Slice.
....
```
