### PR TITLE
Skip container manager check when --dry-run is specified

### DIFF
--- a/scripts/launch-xrd
+++ b/scripts/launch-xrd
@@ -298,7 +298,7 @@ else
 fi
 
 # Check the container manager is found.
-if ! "$CONTAINER_EXE" --version &>/dev/null; then
+if [[ $DRY_RUN == 0 ]] && ! "$CONTAINER_EXE" --version &>/dev/null; then
     echo "Error: Container executable '$CONTAINER_EXE' not found." >&2
     bad_usage
 fi


### PR DESCRIPTION
Skip container manager existence check when --dry-run is specified.

Dry-run shouldn't require the container manager executable existing.

Test - Ran the script with a fake container manager specified.
```
> scripts/launch-xrd  -n -p xrd-control-plane -c docker-foo dummy-image
docker-foo run -it --rm --cap-drop all --cap-add AUDIT_WRITE --cap-add CHOWN --cap-add DAC_OVERRIDE --cap-add FOWNER --cap-add FSETID --cap-add KILL --cap-add MKNOD --cap-add NET_BIND_SERVICE --cap-add NET_RAW --cap-add SETFCAP --cap-add SETGID --cap-add SETUID --cap-add SETPCAP --cap-add SYS_CHROOT --cap-add IPC_LOCK --cap-add NET_ADMIN --cap-add SYS_ADMIN --cap-add SYS_NICE --cap-add SYS_PTRACE --cap-add SYS_RESOURCE --device /dev/fuse --device /dev/net/tun --security-opt apparmor=unconfined --security-opt label=disable --env XR_MGMT_INTERFACES=linux:eth0,chksum dummy-image
```