### PR TITLE
Add python version check to the scripts

### DIFF
--- a/scripts/host-check
+++ b/scripts/host-check
@@ -22,6 +22,7 @@ Check that the host is set up correctly for running XRd containers.
 
 import sys
 
+
 if sys.version_info < (3, 7):
     print(
         "Your python version {} has reached end-of-life.\n"
@@ -57,6 +58,7 @@ from typing import (
     Tuple,
     Union,
 )
+
 
 # pylint: enable=wrong-import-position
 

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -33,6 +33,7 @@ if sys.version_info < (3, 7):
     )
     sys.exit(1)
 
+# pylint: disable=wrong-import-position
 import argparse
 import enum
 import functools
@@ -56,6 +57,8 @@ from typing import (
     Tuple,
     Union,
 )
+
+# pylint: enable=wrong-import-position
 
 
 # -----------------------------------------------------------------------------

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -20,6 +20,19 @@
 Check that the host is set up correctly for running XRd containers.
 """
 
+import sys
+
+if sys.version_info < (3, 7):
+    print(
+        "Your python version {} has reached end-of-life.\n"
+        "Please ensure you have 'python3' at version 3.7 or higher on your "
+        "PATH (check with 'python3 --version').".format(
+            ".".join(str(x) for x in sys.version_info[:2]),
+        ),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
 import argparse
 import enum
 import functools
@@ -28,7 +41,6 @@ import os
 import re
 import shlex
 import subprocess
-import sys
 import textwrap
 from dataclasses import dataclass
 from typing import (

--- a/scripts/xr-compose
+++ b/scripts/xr-compose
@@ -26,6 +26,7 @@ specification of PCI interfaces).
 
 import sys
 
+
 if sys.version_info < (3, 7):
     print(
         "Your python version {} has reached end-of-life.\n"
@@ -49,6 +50,7 @@ from collections import OrderedDict
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 import yaml
+
 
 # pylint: enable=wrong-import-position
 

--- a/scripts/xr-compose
+++ b/scripts/xr-compose
@@ -24,13 +24,25 @@ specification of PCI interfaces).
 
 """
 
+import sys
+
+if sys.version_info < (3, 7):
+    print(
+        "Your python version {} has reached end-of-life.\n"
+        "Please ensure you have 'python3' at version 3.7 or higher on your "
+        "PATH (check with 'python3 --version').".format(
+            ".".join(str(x) for x in sys.version_info[:2]),
+        ),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
 import argparse
 import enum
 import logging
 import os
 import re
 import subprocess
-import sys
 import typing
 from collections import OrderedDict
 from typing import Any, Dict, Iterable, List, Optional, Union

--- a/scripts/xr-compose
+++ b/scripts/xr-compose
@@ -37,6 +37,7 @@ if sys.version_info < (3, 7):
     )
     sys.exit(1)
 
+# pylint: disable=wrong-import-position
 import argparse
 import enum
 import logging
@@ -48,6 +49,8 @@ from collections import OrderedDict
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 import yaml
+
+# pylint: enable=wrong-import-position
 
 
 # --------------


### PR DESCRIPTION
Adding a python version check (> 3.7) to the top of the scripts. This is before the imports because some modules (eg data classes) aren't available on older versions.

Added it to `host-check` and `xr-compose` files.