### PR TITLE
CSCwf20183 Update host-check to treat inability to perform a check as an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 7.9.1.
 
+### v1.1.10 (2023-05-30)
+
+- Add a new 'error' check state for when checks fail to run and update the output message at the bottom of the script, inline with this change.
+
+
 ### v1.1.9 (2023-05-15)
 
 Changes corresponding to the release of XR version 7.9.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 7.9.1.
 
 ### v1.1.10 (2023-05-30)
 
-- Add a new 'error' check state for when checks fail to run and update the output message at the bottom of the script, inline with this change.
+- Add a new 'error' check state to `host-check` for when checks fail to run and update the output message at the bottom of the script, inline with this change.
 
 
 ### v1.1.9 (2023-05-15)

--- a/commit-check
+++ b/commit-check
@@ -65,7 +65,7 @@ fi
 
 echo
 echo "Running tests..."
-if ! pytest; then
+if ! pytest -vv --cov; then
     echo "Tests failed, check output and fix issues." >&2
     FAILURES=$((FAILURES+1))
 fi

--- a/commit-check
+++ b/commit-check
@@ -65,7 +65,7 @@ fi
 
 echo
 echo "Running tests..."
-if ! pytest; then
+if ! pytest "-vv"; then
     echo "Tests failed, check output and fix issues." >&2
     FAILURES=$((FAILURES+1))
 fi

--- a/commit-check
+++ b/commit-check
@@ -65,7 +65,7 @@ fi
 
 echo
 echo "Running tests..."
-if ! pytest --cov -vv; then
+if ! pytest; then
     echo "Tests failed, check output and fix issues." >&2
     FAILURES=$((FAILURES+1))
 fi

--- a/commit-check
+++ b/commit-check
@@ -65,7 +65,7 @@ fi
 
 echo
 echo "Running tests..."
-if ! pytest "-vv"; then
+if ! pytest; then
     echo "Tests failed, check output and fix issues." >&2
     FAILURES=$((FAILURES+1))
 fi

--- a/commit-check
+++ b/commit-check
@@ -65,7 +65,7 @@ fi
 
 echo
 echo "Running tests..."
-if ! pytest -vv --cov; then
+if ! pytest; then
     echo "Tests failed, check output and fix issues." >&2
     FAILURES=$((FAILURES+1))
 fi

--- a/commit-check
+++ b/commit-check
@@ -65,7 +65,7 @@ fi
 
 echo
 echo "Running tests..."
-if ! pytest; then
+if ! pytest --cov -vv; then
     echo "Tests failed, check output and fix issues." >&2
     FAILURES=$((FAILURES+1))
 fi

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1499,7 +1499,7 @@ def perform_checks(checks: List[Check]) -> Mapping[str, CheckState]:
 
 
 def run_if_extra_checks(
-    extra_checks: List[str] = [],
+    extra_checks: Optional[List[str]] = None,
 ) -> Tuple[Set[str], Set[str], Set[str]]:
     """
     Run the specified extra checks, printing the results and returning the

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -673,7 +673,7 @@ def check_realtime_group_sched() -> CheckFuncReturn:
                     return CheckState.SUCCESS, "disabled at runtime"
         except Exception:
             return (
-                CheckState.WARNING,
+                CheckState.ERROR,
                 f"Failed to read {kernel_sched_rt_path}, unable to check if\n"
                 f"real-time group scheduling is disabled.\n" + recommendation,
             )
@@ -1620,7 +1620,6 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
     print_heading("Platform checks")
     print_subheading("base checks")
     base_success, base_check_errors = perform_checks(BASE_CHECKS)
-
     for platform, checks in PLATFORM_CHECKS_MAP.items():
         print_subheading(f"{platform} checks")
         platform_success, plat_check_errors = perform_checks(checks)

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -322,7 +322,7 @@ class CheckState(enum.Enum):
     WARNING = "warning"
     SKIPPED = "skipped"
     FAILED = "failed"
-    ERROR = "error"  # Check state for when the check itself fails
+    ERROR = "error"  # Check state for when the check fails to run/errors
     NEUTRAL = "neutral"
 
     def is_error(self) -> bool:
@@ -1429,7 +1429,7 @@ def perform_checks(checks: List[Check]) -> Tuple[bool, bool]:
     :param checks:
         Checks to run through.
     :return:
-        Whether all required checks succeeded.
+        Whether all required checks succeeded, and whether any checks errored.
     """
     results: Dict[str, CheckState] = {}
     msg: Optional[str]
@@ -1458,7 +1458,7 @@ def perform_checks(checks: List[Check]) -> Tuple[bool, bool]:
         results[name] = status
 
     success = not any(c.is_error() for c in results.values())
-    errored_checks = any(c.ERROR for c in results.values())
+    errored_checks = any(c is CheckState.ERROR for c in results.values())
     return success, errored_checks
 
 
@@ -1540,7 +1540,7 @@ def run_checks_specific_platform(
     print(f"\n{DOUBLE_DASHED_LINE}")
     if platform_success and errored_checks:
         print_without_newline(
-            f"Unable to determine if host is set up correctly for {platform}"
+            f"One or more checks could not be performed, see errors above"
         )
     elif platform_success and not errored_checks:
         print_without_newline(
@@ -1565,10 +1565,11 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
     :return:
         Whether at least one XR platform is supported.
     """
-    platforms_supported = set()
-    platforms_not_supported = set()
+    platforms_supported: Set[str] = set()
+    platforms_not_supported: Set[str] = set()
     extras_supported: Set[str] = set()
     extras_not_supported: Set[str] = set()
+    platforms_with_errored_checks: Set[str] = set()
 
     print_heading("Platform checks")
     print_subheading("base checks")
@@ -1576,7 +1577,10 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
 
     for platform, checks in PLATFORM_CHECKS_MAP.items():
         print_subheading(f"{platform} checks")
-        platform_success = perform_checks(checks)
+        platform_success, errored_checks = perform_checks(checks)
+
+        if errored_checks:
+            platforms_with_errored_checks.add(platform)
 
         if base_success and platform_success:
             platforms_supported.add(platform)
@@ -1588,13 +1592,17 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
 
     print(f"\n{DOUBLE_DASHED_LINE}")
 
-    if platforms_supported:
+    if platforms_with_errored_checks:
         print_without_newline(
-            "XR platforms supported: " + ", ".join(sorted(platforms_supported))
+            "One or more checks could not be performed, see errors above"
         )
     elif not platforms_supported:
         print_without_newline(
             "!! Host NOT set up correctly for any XR platforms !!"
+        )
+    else:
+        print_without_newline(
+            "XR platforms supported: " + ", ".join(sorted(platforms_supported))
         )
     if platforms_not_supported and platforms_supported:
         print_without_newline(

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -322,6 +322,7 @@ class CheckState(enum.Enum):
     WARNING = "warning"
     SKIPPED = "skipped"
     FAILED = "failed"
+    ERROR = "error"  # Check state for when the check itself fails
     NEUTRAL = "neutral"
 
     def is_error(self) -> bool:
@@ -352,7 +353,7 @@ def check_arch() -> CheckFuncReturn:
             )
     except subprocess.SubprocessError:
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             "Unable to check the CPU architecture with 'uname -m'.\n"
             "XRd supports the following architectures: "
             f"{', '.join(SUPPORTED_ARCHES)}.",
@@ -372,7 +373,7 @@ def check_cpu_cores() -> CheckFuncReturn:
         match = re.search(r"CPU\(s\):\s+(\d+)\s+", output)
         if not match:
             return (
-                CheckState.WARNING,
+                CheckState.ERROR,
                 f"Unable to parse the output from {cmd!r} -\n"
                 "unable to check the number of available CPU cores.\n"
                 + expected_cpus_msg,
@@ -386,7 +387,7 @@ def check_cpu_cores() -> CheckFuncReturn:
             )
     except subprocess.SubprocessError:
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             f"Error running {cmd!r} to check the number of available CPU cores.\n"
             + expected_cpus_msg,
         )
@@ -403,7 +404,7 @@ def check_kernel_version() -> CheckFuncReturn:
 
     except Exception:
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             "Unable to check the kernel version - must be at least version 4.0",
         )
 
@@ -502,7 +503,7 @@ def check_inotify_limits(setting: str) -> CheckFuncReturn:
             val = int(f.read().strip())
     except Exception:
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             f"Failed to check inotify resource limits by reading\n"
             f"{path}.\n"
             f"The kernel parameter fs.inotify.{setting} should be set to at least {INOTIFY_PER_CONTAINER}\n"
@@ -566,7 +567,7 @@ def check_userspace_aslr() -> CheckFuncReturn:
             val = int(f.read().strip())
     except Exception:
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             f"Failed to read {path}, which controls ASLR\n"
             f"(Address-Space Layout Randomization).\n" + recommendation,
         )
@@ -655,7 +656,7 @@ def check_socket_parameters() -> CheckFuncReturn:
                 val = int(f.read().strip())
         except Exception:
             return (
-                CheckState.WARNING,
+                CheckState.ERROR,
                 f"Failed to read socket kernel parameter {path}.",
             )
 
@@ -703,7 +704,7 @@ def check_udp_parameters() -> CheckFuncReturn:
             val = f.read().strip().split()
     except Exception:
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             f"Failed to read UDP kernel parameter {path}.",
         )
 
@@ -755,7 +756,7 @@ def check_ram(ram_req: int) -> CheckFuncReturn:
         output = run_cmd(shlex.split(cmd))[0]
     except subprocess.SubprocessError:
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             f"The command {cmd!r} failed - unable to determine the available RAM on\n"
             f"the host.\n" + xrd_expected_usage_str,
         )
@@ -770,7 +771,7 @@ def check_ram(ram_req: int) -> CheckFuncReturn:
         free_mem = int(output.split("\n")[1].split()[-1]) / (2**30)
     except Exception:
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             f"Failed to parse the output from {cmd!r} - unable to determine the\n"
             f"available RAM on the host.\n" + xrd_expected_usage_str,
         )
@@ -804,7 +805,7 @@ def check_cpu_extensions() -> CheckFuncReturn:
         match = re.search(r"Flags:\s+(.+)", output)
         if not match:
             return (
-                CheckState.WARNING,
+                CheckState.ERROR,
                 f"Unable to parse the output from {cmd!r} - unable to check\n"
                 f"for the required CPU extensions: "
                 + ", ".join(sorted(required_cpu_exts))
@@ -825,7 +826,7 @@ def check_cpu_extensions() -> CheckFuncReturn:
             )
     except subprocess.SubprocessError:
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             f"Unable to parse the output from {cmd!r} - unable to check\n"
             f"for the required CPU extensions: "
             + ", ".join(sorted(required_cpu_exts))
@@ -919,7 +920,7 @@ def check_hugepages() -> CheckFuncReturn:
                 return check_state, "\n".join(msgs)
     except OSError:
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             f"Unable to parse the contents of {path} - unable to check\n"
             f"whether hugepages are enabled with 1GiB (recommended)\n"
             f"or 2MiB hugepage size and at least {HUGEPAGE_MEMORY_GB}GiB of available\n"
@@ -927,7 +928,7 @@ def check_hugepages() -> CheckFuncReturn:
         )
     except (ValueError, IndexError):
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             f"Unable to parse the contents of {path} - unable to check\n"
             f"whether hugepages are enabled with 1GiB (recommended)\n"
             f"or 2MiB hugepage size and at least {HUGEPAGE_MEMORY_GB}GiB of available\n"
@@ -1105,7 +1106,7 @@ def check_shmem_pages_max_size() -> CheckFuncReturn:
                 shared_mem_max_page_size = int(contents) / (2**30)
             except ValueError:
                 return (
-                    CheckState.WARNING,
+                    CheckState.ERROR,
                     f"Unable to parse the contents of {path} - unable to\n"
                     f"determine the maximum size of shared memory pages.\n"
                     f"At least {SHARED_MEM_MAX_PAGE_SIZE_GB} GiB are required.",
@@ -1119,7 +1120,7 @@ def check_shmem_pages_max_size() -> CheckFuncReturn:
                 )
     except OSError:
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             f"Unable to read the contents of {path} - unable to\n"
             f"determine the maximum size of shared memory pages.\n"
             f"At least {SHARED_MEM_MAX_PAGE_SIZE_GB} GiB are required.",
@@ -1152,7 +1153,7 @@ def check_docker_client() -> CheckFuncReturn:
     )
     if not version_match:
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             f"Unable to parse Docker client version from {cmd!r}.\n"
             f"At least version 18.0 is required for XRd.",
         )
@@ -1185,7 +1186,7 @@ def check_docker_daemon() -> CheckFuncReturn:
     version_match = re.match(r'"(\d+\.\d+(?:\.\d+)?)"', version_str)
     if not version_match:
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             f"Unable to parse Docker server version from\n"
             f"{cmd!r}.\n"
             f"At least version 18.0 is required for XRd.",
@@ -1249,7 +1250,7 @@ def check_docker_compose() -> CheckFuncReturn:
     )
     if not version_match:
         return (
-            CheckState.WARNING,
+            CheckState.ERROR,
             "Unable to parse Docker Compose version, at least version 1.18 is required.",
         )
     version = version_match.group(1)
@@ -1301,7 +1302,7 @@ def check_bridge_iptables() -> CheckFuncReturn:
                 val = int(f.read().strip())
         except Exception:
             return (
-                CheckState.WARNING,
+                CheckState.ERROR,
                 f"Failed to read iptables settings under {base_path}/.\n"
                 + long_msg,
             )
@@ -1393,19 +1394,22 @@ def print_check_status_msg(
 ) -> None:
     if status is CheckState.SUCCESS:
         colour = green
-        status_word = "PASS"
+        status_word = " PASS"
     elif status is CheckState.WARNING:
         colour = yellow
-        status_word = "WARN"
+        status_word = " WARN"
     elif status is CheckState.SKIPPED:
         colour = yellow
-        status_word = "SKIP"
+        status_word = " SKIP"
     elif status is CheckState.FAILED:
         colour = red
-        status_word = "FAIL"
+        status_word = " FAIL"
+    elif status is CheckState.ERROR:
+        colour = red
+        status_word = "ERROR"
     elif status is CheckState.NEUTRAL:
         colour = cyan
-        status_word = "INFO"
+        status_word = " INFO"
     else:
         assert False
 
@@ -1413,12 +1417,12 @@ def print_check_status_msg(
     if msg and len(msg) < 32:
         output += f" ({msg})"
     elif msg:
-        output += "\n" + textwrap.indent(msg, "        ")
+        output += "\n" + textwrap.indent(msg, "         ")
 
     print(colour(output))
 
 
-def perform_checks(checks: List[Check]) -> bool:
+def perform_checks(checks: List[Check]) -> Tuple[bool, bool]:
     """
     Perform host checks.
 
@@ -1441,7 +1445,7 @@ def perform_checks(checks: List[Check]) -> bool:
                     status = CheckState.SUCCESS
                     msg = None
             except CmdTimeoutError as e:
-                status = CheckState.WARNING
+                status = CheckState.ERROR
                 msg = f"Unexpected error: {e}"
             except Exception as e:
                 status = CheckState.FAILED
@@ -1453,7 +1457,9 @@ def perform_checks(checks: List[Check]) -> bool:
 
         results[name] = status
 
-    return not any(c.is_error() for c in results.values())
+    success = not any(c.is_error() for c in results.values())
+    errored_checks = any(c.ERROR for c in results.values())
+    return success, errored_checks
 
 
 def run_extra_checks(extra_checks: List[str]) -> Tuple[Set[str], Set[str]]:
@@ -1475,7 +1481,7 @@ def run_extra_checks(extra_checks: List[str]) -> Tuple[Set[str], Set[str]]:
     print_heading("Extra checks")
     for extra_check in sorted(extra_checks):
         print_subheading(f"{extra_check} checks")
-        extra_success = perform_checks(EXTRA_CHECKS_MAP[extra_check])
+        extra_success, _ = perform_checks(EXTRA_CHECKS_MAP[extra_check])
         if extra_success:
             extras_supported.add(extra_check)
         else:
@@ -1524,7 +1530,7 @@ def run_checks_specific_platform(
     """
     extras_not_supported: Set[str] = set()
     print_heading(f"Platform checks - {platform}")
-    platform_success = perform_checks(
+    platform_success, errored_checks = perform_checks(
         BASE_CHECKS + PLATFORM_CHECKS_MAP[platform]
     )
 
@@ -1532,7 +1538,11 @@ def run_checks_specific_platform(
         extras_supported, extras_not_supported = run_extra_checks(extra_checks)
 
     print(f"\n{DOUBLE_DASHED_LINE}")
-    if platform_success:
+    if platform_success and errored_checks:
+        print_without_newline(
+            f"Unable to determine if host is set up correctly for {platform}"
+        )
+    elif platform_success and not errored_checks:
         print_without_newline(
             f"Host environment set up correctly for {platform}"
         )

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -330,6 +330,7 @@ class CheckState(enum.Enum):
             CheckState.FAILED,
             CheckState.SKIPPED,
             CheckState.WARNING,
+            CheckState.ERROR,
         ]
 
 
@@ -1042,7 +1043,7 @@ def check_iommu() -> CheckFuncReturn:
             )
     except Exception:
         return (
-            warning_state,
+            CheckState.ERROR,
             f"Unable to check if IOMMU is enabled by listing {iommu_dev_filepath}.\n"
             + recommendation,
         )
@@ -1066,7 +1067,7 @@ def check_iommu() -> CheckFuncReturn:
 
     except subprocess.SubprocessError:
         return (
-            warning_state,
+            CheckState.ERROR,
             f"The cmd {cmd!r} failed - unable to\n"
             "determine the network devices on the host. IOMMU is enabled.",
         )
@@ -1538,11 +1539,11 @@ def run_checks_specific_platform(
         extras_supported, extras_not_supported = run_extra_checks(extra_checks)
 
     print(f"\n{DOUBLE_DASHED_LINE}")
-    if platform_success and errored_checks:
+    if errored_checks:
         print_without_newline(
-            f"One or more checks could not be performed, see errors above"
+            "!! One or more checks could not be performed, see errors above !!"
         )
-    elif platform_success and not errored_checks:
+    elif platform_success:
         print_without_newline(
             f"Host environment set up correctly for {platform}"
         )
@@ -1573,13 +1574,13 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
 
     print_heading("Platform checks")
     print_subheading("base checks")
-    base_success = perform_checks(BASE_CHECKS)
+    base_success, base_check_errors = perform_checks(BASE_CHECKS)
 
     for platform, checks in PLATFORM_CHECKS_MAP.items():
         print_subheading(f"{platform} checks")
-        platform_success, errored_checks = perform_checks(checks)
+        platform_success, plat_check_errors = perform_checks(checks)
 
-        if errored_checks:
+        if base_check_errors or plat_check_errors:
             platforms_with_errored_checks.add(platform)
 
         if base_success and platform_success:
@@ -1594,7 +1595,7 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
 
     if platforms_with_errored_checks:
         print_without_newline(
-            "One or more checks could not be performed, see errors above"
+            "!! One or more checks could not be performed, see errors above !!"
         )
     elif not platforms_supported:
         print_without_newline(

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -237,16 +237,6 @@ def print_subheading(subheading: str) -> None:
     print("\n" + subheading + "\n-----------------------")
 
 
-def print_without_newline(string: str) -> None:
-    """
-    Print a string but don't add a newline afterwards.
-
-    :param string:
-        The string to print.
-    """
-    print(string, end="")
-
-
 def _is_module_installed(module: str) -> bool:
     """
     Check if a module is named in any of the listed modules.
@@ -314,24 +304,27 @@ def _get_cgroup_version() -> int:
 class CheckState(enum.Enum):
     """The result state of a check."""
 
+    # 'success' check states
     SUCCESS = "success"
     NEUTRAL = "neutral"
-
+    # 'failure' check states
     WARNING = "warning"
     SKIPPED = "skipped"
     FAILED = "failed"
-
-    ERROR = "error"  # Check state for when the check fails to run/errors
+    # Check state for when the check fails to run/errors
+    # Note: this is neither 'success' nor 'failure'
+    ERROR = "error"
 
     def is_failure(self) -> bool:
+        """
+        Returns True for check states that are classed as 'failure'.
+        Note: errors (CheckState.ERROR) are treated as separate.
+        """
         return self in [
             CheckState.FAILED,
             CheckState.SKIPPED,
             CheckState.WARNING,
         ]
-
-    def is_success(self) -> bool:
-        return self in [CheckState.SUCCESS, CheckState.NEUTRAL]
 
 
 CheckFuncReturn = Optional[Tuple[CheckState, str]]
@@ -1492,9 +1485,6 @@ def perform_checks(checks: List[Check]) -> Mapping[str, CheckState]:
                 else:
                     status = CheckState.SUCCESS
                     msg = None
-            except CmdTimeoutError as e:
-                status = CheckState.ERROR
-                msg = f"Command timed out: {e}"
             except Exception as e:
                 status = CheckState.ERROR
                 msg = f"Unexpected error: {e}"
@@ -1506,6 +1496,63 @@ def perform_checks(checks: List[Check]) -> Mapping[str, CheckState]:
         results[name] = status
 
     return results
+
+
+def run_if_extra_checks(
+    extra_checks: List[str] = [],
+) -> Tuple[Set[str], Set[str], Set[str]]:
+    """
+    Run the specified extra checks, printing the results and returning the
+    checks that succeeded, failed and errored.
+    :param extra_checks:
+        List of extra checks to perform.
+    :returns:
+        Tuple of the checks that: succeeded, failed and errored.
+    """
+    extras_supported = set()
+    extras_not_supported = set()
+    extras_errored = set()
+
+    if extra_checks:
+        print("")  # insert a newline
+        print_heading("Extra checks")
+        for extra_check in sorted(extra_checks):
+            print_subheading(f"{extra_check} checks")
+            extra_results = perform_checks(EXTRA_CHECKS_MAP[extra_check])
+
+            if any(check.is_failure() for check in extra_results.values()):
+                extras_not_supported.add(extra_check)
+            elif any(c is CheckState.ERROR for c in extra_results.values()):
+                extras_errored.add(extra_check)
+            else:
+                extras_supported.add(extra_check)
+
+    return extras_supported, extras_not_supported, extras_errored
+
+
+def print_extra_checks_summary(
+    extras_supported: Set[str],
+    extras_not_supported: Set[str],
+    extras_errored: Set[str],
+) -> None:
+    """
+    Print a summary of the extra checks that passed and failed.
+    :param extras_supported:
+        The checks that were successful.
+    :param extras_not_supported:
+        The checks that were not successful.
+    :param extras_errored:
+        The checks that errored/failed to run.
+    """
+    print(f"{DASHED_LINE}")
+    if extras_supported:
+        print("Extra checks passed: " + ", ".join(sorted(extras_supported)))
+    if extras_not_supported:
+        print(
+            "Extra checks failed: " + ", ".join(sorted(extras_not_supported))
+        )
+    if extras_errored:
+        print("Extra checks errored: " + ", ".join(sorted(extras_errored)))
 
 
 def run_checks_specific_platform(
@@ -1522,60 +1569,33 @@ def run_checks_specific_platform(
     :return:
         Whether all checks that were performed succeeded.
     """
-    extras_supported: Set[str] = set()
-    extras_not_supported: Set[str] = set()
-    extras_errored: Set[str] = set()
 
     print_heading(f"Platform checks - {platform}")
     plat_results = perform_checks(BASE_CHECKS + PLATFORM_CHECKS_MAP[platform])
     plat_failure = any(check.is_failure() for check in plat_results.values())
     plat_error = any(c is CheckState.ERROR for c in plat_results.values())
 
-    if extra_checks:
-        print("")  # insert a newline
-        print_heading("Extra checks")
-        for extra_check in sorted(extra_checks):
-            print_subheading(f"{extra_check} checks")
-            extra_results = perform_checks(EXTRA_CHECKS_MAP[extra_check])
-
-            if any(check.is_failure() for check in extra_results.values()):
-                extras_not_supported.add(extra_check)
-            elif any(c is CheckState.ERROR for c in extra_results.values()):
-                extras_errored.add(extra_check)
-            else:
-                extras_supported.add(extra_check)
+    (
+        extras_supported,
+        extras_not_supported,
+        extras_errored,
+    ) = run_if_extra_checks(extra_checks)
 
     # Print a summary of what is and is not supported
-    print_without_newline(f"\n{DOUBLE_DASHED_LINE}")
+    print(f"\n{DOUBLE_DASHED_LINE}")
     if plat_failure:
-        print_without_newline(
-            f"\n!! Host NOT set up correctly for {platform} !!"
-        )
+        print(f"!! Host NOT set up correctly for {platform} !!")
     elif plat_error:
-        print_without_newline(
-            "\n!! One or more platform checks could not be performed, see errors above !!"
+        print(
+            "!! One or more platform checks could not be performed, see errors above !!"
         )
     else:
-        print_without_newline(
-            f"\nHost environment set up correctly for {platform}"
-        )
-    # Print the result of any extra checks
+        print(f"Host environment set up correctly for {platform}")
     if extra_checks:
-        print_without_newline(f"\n{DASHED_LINE}")
-        if extras_supported:
-            print_without_newline(
-                "\nExtra checks passed: " + ", ".join(sorted(extras_supported))
-            )
-        if extras_not_supported:
-            print_without_newline(
-                "\nExtra checks failed: "
-                + ", ".join(sorted(extras_not_supported))
-            )
-        if any(c is CheckState.ERROR for c in extra_results.values()):
-            print_without_newline(
-                "\nExtra checks errored: " + ", ".join(sorted(extras_errored))
-            )
-    print(f"\n{DOUBLE_DASHED_LINE}")
+        print_extra_checks_summary(
+            extras_supported, extras_not_supported, extras_errored
+        )
+    print(f"{DOUBLE_DASHED_LINE}")
 
     return not (
         plat_failure or plat_error or extras_not_supported or extras_errored
@@ -1592,9 +1612,6 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
     platforms_supported: Set[str] = set()
     platforms_not_supported: Set[str] = set()
     platforms_errored: Set[str] = set()
-    extras_supported: Set[str] = set()
-    extras_not_supported: Set[str] = set()
-    extras_errored: Set[str] = set()
 
     print_heading("Platform checks")
     print_subheading("base checks")
@@ -1602,63 +1619,45 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
     for platform, checks in PLATFORM_CHECKS_MAP.items():
         print_subheading(f"{platform} checks")
         plat_results = perform_checks(checks)
-        b_and_p_results = list(base_results.values()) + list(
+        base_and_plat_results = list(base_results.values()) + list(
             plat_results.values()
         )
-        if any(result.is_failure() for result in b_and_p_results):
+        if any(result.is_failure() for result in base_and_plat_results):
             platforms_not_supported.add(platform)
-        elif any(result is CheckState.ERROR for result in b_and_p_results):
+        elif any(
+            result is CheckState.ERROR for result in base_and_plat_results
+        ):
             platforms_errored.add(platform)
         else:
             platforms_supported.add(platform)
 
-    if extra_checks:
-        print("")  # insert a newline
-        print_heading("Extra checks")
-        for extra_check in sorted(extra_checks):
-            print_subheading(f"{extra_check} checks")
-            extra_results = perform_checks(EXTRA_CHECKS_MAP[extra_check])
-
-            if any(check.is_failure() for check in extra_results.values()):
-                extras_not_supported.add(extra_check)
-            elif any(c is CheckState.ERROR for c in extra_results.values()):
-                extras_errored.add(extra_check)
-            else:
-                extras_supported.add(extra_check)
+    (
+        extras_supported,
+        extras_not_supported,
+        extras_errored,
+    ) = run_if_extra_checks(extra_checks)
 
     # Print a summary of what is and is not supported
-    print_without_newline(f"\n{DOUBLE_DASHED_LINE}")
+    print(f"\n{DOUBLE_DASHED_LINE}")
     if platforms_supported:
-        print_without_newline(
-            "\nXR platforms supported: "
-            + ", ".join(sorted(platforms_supported))
+        print(
+            "XR platforms supported: " + ", ".join(sorted(platforms_supported))
         )
     if platforms_not_supported:
-        print_without_newline(
-            "\nXR platforms NOT supported: "
+        print(
+            "XR platforms NOT supported: "
             + ", ".join(sorted(platforms_not_supported))
         )
     if platforms_errored:
-        print_without_newline(
-            "\n!! One or more platform checks could not be performed, see errors above !!"
+        print(
+            "!! One or more platform checks could not be performed, see errors above !!"
         )
     # Print the result of any extra checks
     if extra_checks:
-        print_without_newline(f"\n{DASHED_LINE}")
-        if extras_supported:
-            print_without_newline(
-                "\nExtra checks passed: " + ", ".join(sorted(extras_supported))
-            )
-        if extras_not_supported:
-            print_without_newline(
-                "\nExtra checks failed: "
-                + ", ".join(sorted(extras_not_supported))
-            )
-        if any(c is CheckState.ERROR for c in extra_results.values()):
-            print_without_newline(
-                "\nExtra checks errored: " + ", ".join(sorted(extras_errored))
-            )
-    print(f"\n{DOUBLE_DASHED_LINE}")
+        print_extra_checks_summary(
+            extras_supported, extras_not_supported, extras_errored
+        )
+    print(f"{DOUBLE_DASHED_LINE}")
 
     return len(platforms_supported) > 0
 

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -334,7 +334,38 @@ class CheckState(enum.Enum):
         ]
 
 
+class OverallCheckState(enum.Enum):
+    """The overall result state of multiple checks."""
+
+    ALL_SUCCEEDED = "all succeeded"
+    FAILURES = "failures"
+    ERRORS = "errors"
+
+    def is_success(self) -> bool:
+        return self is OverallCheckState.ALL_SUCCEEDED
+
+
+def overall_check_state(results: Dict[str, CheckState]) -> OverallCheckState:
+    """
+    Determine the overall check state for the given results.
+
+    :param results:
+        Dictionary of results.
+    :return:
+        The overall result state.
+    """
+    success = not any(c.is_error() for c in results.values())
+    errored_checks = any(c is CheckState.ERROR for c in results.values())
+    if success:
+        return OverallCheckState.ALL_SUCCEEDED
+    if errored_checks:
+        return OverallCheckState.ERRORS
+    else:
+        return OverallCheckState.FAILURES
+
+
 CheckFuncReturn = Optional[Tuple[CheckState, str]]
+
 
 # -------------------------------------
 # Base checks
@@ -1440,26 +1471,26 @@ def print_check_status_msg(
 ) -> None:
     if status is CheckState.SUCCESS:
         colour = green
-        status_word = " PASS"
+        status_word = "PASS"
     elif status is CheckState.WARNING:
         colour = yellow
-        status_word = " WARN"
+        status_word = "WARN"
     elif status is CheckState.SKIPPED:
         colour = yellow
-        status_word = " SKIP"
+        status_word = "SKIP"
     elif status is CheckState.FAILED:
         colour = red
-        status_word = " FAIL"
+        status_word = "FAIL"
     elif status is CheckState.ERROR:
         colour = red
         status_word = "ERROR"
     elif status is CheckState.NEUTRAL:
         colour = cyan
-        status_word = " INFO"
+        status_word = "INFO"
     else:
         assert False
 
-    output = f"{status_word} -- {name}"
+    output = f"{status_word:>5} -- {name}"
     if msg and len(msg) < 32:
         output += f" ({msg})"
     elif msg:
@@ -1468,7 +1499,50 @@ def print_check_status_msg(
     print(colour(output))
 
 
-def perform_checks(checks: List[Check]) -> Tuple[bool, bool]:
+def print_summary_specific_platform(
+    result: OverallCheckState, platform: str
+) -> None:
+    if result is OverallCheckState.ERRORS:
+        summary = (
+            "!! One or more checks could not be performed, see errors above !!"
+        )
+    elif result is OverallCheckState.ALL_SUCCEEDED:
+        summary = f"Host environment set up correctly for {platform}"
+    elif result is OverallCheckState.FAILURES:
+        summary = f"!! Host NOT set up correctly for {platform} !!"
+    else:
+        assert False
+    print_without_newline(summary)
+
+
+def print_summary_all_platforms(
+    plats_supported: Set[str], plats_errored: Set[str]
+) -> None:
+    plats_not_supported = {
+        "xrd-control-plane",
+        "xrd-vrouter",
+    } - plats_supported
+
+    if plats_errored:
+        print_without_newline(
+            "!! One or more checks could not be performed, see errors above !!"
+        )
+    elif not plats_supported:
+        print_without_newline(
+            "!! Host NOT set up correctly for any XR platforms !!"
+        )
+    else:
+        print_without_newline(
+            "XR platforms supported: " + ", ".join(sorted(plats_supported))
+        )
+    if plats_not_supported and plats_supported:
+        print_without_newline(
+            "\nXR platforms NOT supported: "
+            + ", ".join(sorted(plats_not_supported))
+        )
+
+
+def perform_checks(checks: List[Check]) -> OverallCheckState:
     """
     Perform host checks.
 
@@ -1503,9 +1577,7 @@ def perform_checks(checks: List[Check]) -> Tuple[bool, bool]:
 
         results[name] = status
 
-    success = not any(c.is_error() for c in results.values())
-    errored_checks = any(c is CheckState.ERROR for c in results.values())
-    return success, errored_checks
+    return overall_check_state(results)
 
 
 def run_extra_checks(extra_checks: List[str]) -> Tuple[Set[str], Set[str]]:
@@ -1527,8 +1599,8 @@ def run_extra_checks(extra_checks: List[str]) -> Tuple[Set[str], Set[str]]:
     print_heading("Extra checks")
     for extra_check in sorted(extra_checks):
         print_subheading(f"{extra_check} checks")
-        extra_success, _ = perform_checks(EXTRA_CHECKS_MAP[extra_check])
-        if extra_success:
+        result = perform_checks(EXTRA_CHECKS_MAP[extra_check])
+        if result.is_success():
             extras_supported.add(extra_check)
         else:
             extras_not_supported.add(extra_check)
@@ -1576,32 +1648,18 @@ def run_checks_specific_platform(
     """
     extras_not_supported: Set[str] = set()
     print_heading(f"Platform checks - {platform}")
-    platform_success, errored_checks = perform_checks(
-        BASE_CHECKS + PLATFORM_CHECKS_MAP[platform]
-    )
+    result = perform_checks(BASE_CHECKS + PLATFORM_CHECKS_MAP[platform])
 
     if extra_checks is not None:  # check if any extra checks were specified
         extras_supported, extras_not_supported = run_extra_checks(extra_checks)
 
     print(f"\n{DOUBLE_DASHED_LINE}")
-    if errored_checks:
-        print_without_newline(
-            "!! One or more checks could not be performed, see errors above !!"
-        )
-    elif platform_success:
-        print_without_newline(
-            f"Host environment set up correctly for {platform}"
-        )
-    else:
-        print_without_newline(
-            f"!! Host NOT set up correctly for {platform} !!"
-        )
-
+    print_summary_specific_platform(result, platform)
     if extra_checks is not None:
         print_extra_checks_summary(extras_supported, extras_not_supported)
     print(f"\n{DOUBLE_DASHED_LINE}")
 
-    return platform_success and not extras_not_supported
+    return result.is_success() and not extras_not_supported
 
 
 def run_checks_all_platforms(extra_checks: List[str]) -> bool:
@@ -1613,21 +1671,21 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
     """
     platforms_supported: Set[str] = set()
     platforms_not_supported: Set[str] = set()
+    platforms_with_errored_checks: Set[str] = set()
     extras_supported: Set[str] = set()
     extras_not_supported: Set[str] = set()
-    platforms_with_errored_checks: Set[str] = set()
 
     print_heading("Platform checks")
     print_subheading("base checks")
-    base_success, base_check_errors = perform_checks(BASE_CHECKS)
+    base_result = perform_checks(BASE_CHECKS)
     for platform, checks in PLATFORM_CHECKS_MAP.items():
         print_subheading(f"{platform} checks")
-        platform_success, plat_check_errors = perform_checks(checks)
+        plat_result = perform_checks(checks)
 
-        if base_check_errors or plat_check_errors:
+        if OverallCheckState.ERRORS in [base_result, plat_result]:
             platforms_with_errored_checks.add(platform)
 
-        if base_success and platform_success:
+        if base_result.is_success() and plat_result.is_success():
             platforms_supported.add(platform)
         else:
             platforms_not_supported.add(platform)
@@ -1636,28 +1694,11 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
         extras_supported, extras_not_supported = run_extra_checks(extra_checks)
 
     print(f"\n{DOUBLE_DASHED_LINE}")
-
-    if platforms_with_errored_checks:
-        print_without_newline(
-            "!! One or more checks could not be performed, see errors above !!"
-        )
-    elif not platforms_supported:
-        print_without_newline(
-            "!! Host NOT set up correctly for any XR platforms !!"
-        )
-    else:
-        print_without_newline(
-            "XR platforms supported: " + ", ".join(sorted(platforms_supported))
-        )
-    if platforms_not_supported and platforms_supported:
-        print_without_newline(
-            "\nXR platforms NOT supported: "
-            + ", ".join(sorted(platforms_not_supported))
-        )
-
+    print_summary_all_platforms(
+        platforms_supported, platforms_with_errored_checks
+    )
     if extra_checks:
         print_extra_checks_summary(extras_supported, extras_not_supported)
-
     print(f"\n{DOUBLE_DASHED_LINE}")
 
     return len(platforms_supported) > 0

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -352,7 +352,7 @@ def overall_check_state(results: Dict[str, CheckState]) -> OverallCheckState:
     :param results:
         Dictionary of results.
     :return:
-        The overall result state.
+        The overall check state.
     """
     success = not any(c.is_error() for c in results.values())
     errored_checks = any(c is CheckState.ERROR for c in results.values())
@@ -1549,7 +1549,7 @@ def perform_checks(checks: List[Check]) -> OverallCheckState:
     :param checks:
         Checks to run through.
     :return:
-        Whether all required checks succeeded, and whether any checks errored.
+        The overall result of the checks.
     """
     results: Dict[str, CheckState] = {}
     msg: Optional[str]

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -91,12 +91,8 @@ BOLD_STYLE = 1
 
 REQUIRED_CGROUP_MOUNTS = ["systemd", "memory", "pids", "cpu", "cpuset"]
 
-DASHED_LINE = (
-    "------------------------------------------------------------------"
-)
-DOUBLE_DASHED_LINE = (
-    "=================================================================="
-)
+DASHED_LINE = "----------------------------------------------------------------------------"
+DOUBLE_DASHED_LINE = "============================================================================"
 
 # -----------------------------------------------------------------------------
 # Colours
@@ -319,11 +315,13 @@ class CheckState(enum.Enum):
     """The result state of a check."""
 
     SUCCESS = "success"
+    NEUTRAL = "neutral"
+
     WARNING = "warning"
     SKIPPED = "skipped"
     FAILED = "failed"
+
     ERROR = "error"  # Check state for when the check fails to run/errors
-    NEUTRAL = "neutral"
 
     def is_failure(self) -> bool:
         return self in [
@@ -331,6 +329,9 @@ class CheckState(enum.Enum):
             CheckState.SKIPPED,
             CheckState.WARNING,
         ]
+
+    def is_success(self) -> bool:
+        return self in [CheckState.SUCCESS, CheckState.NEUTRAL]
 
 
 class OverallCheckState(enum.Enum):
@@ -1572,32 +1573,37 @@ def run_checks_specific_platform(
     print_without_newline(f"\n{DOUBLE_DASHED_LINE}")
     if plat_failure:
         print_without_newline(
-            f"\n!! Host not set up correctly for {platform} !!"
+            f"\n!! Host NOT set up correctly for {platform} !!"
         )
     elif plat_error:
         print_without_newline(
             "\n!! One or more platform checks could not be performed, see errors above !!"
         )
     else:
-        print_without_newline(f"\nHost is set up correctly for {platform} :D")
+        print_without_newline(
+            f"\nHost environment set up correctly for {platform}"
+        )
     # Print the result of any extra checks
     if extra_checks:
         print_without_newline(f"\n{DASHED_LINE}")
         if extras_supported:
             print_without_newline(
-                "\nExtra checks passed: " + ", ".join(extras_supported)
+                "\nExtra checks passed: " + ", ".join(sorted(extras_supported))
             )
         if extras_not_supported:
             print_without_newline(
-                "\nExtra checks failed: " + ", ".join(extras_not_supported)
+                "\nExtra checks failed: "
+                + ", ".join(sorted(extras_not_supported))
             )
         if any(c is CheckState.ERROR for c in extra_results.values()):
             print_without_newline(
-                "\nExtra checks errored: " + ", ".join(extras_errored)
+                "\nExtra checks errored: " + ", ".join(sorted(extras_errored))
             )
     print(f"\n{DOUBLE_DASHED_LINE}")
 
-    return not (plat_failure or plat_error)
+    return not (
+        plat_failure or plat_error or extras_not_supported or extras_errored
+    )
 
 
 def run_checks_all_platforms(extra_checks: List[str]) -> bool:
@@ -1645,35 +1651,37 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
                 extras_supported.add(extra_check)
 
     # Print a summary of what is and is not supported
-    print(f"\n{DOUBLE_DASHED_LINE}")
+    print_without_newline(f"\n{DOUBLE_DASHED_LINE}")
     if platforms_supported:
         print_without_newline(
-            "XR platforms supported: " + ", ".join(platforms_supported)
+            "\nXR platforms supported: "
+            + ", ".join(sorted(platforms_supported))
         )
     if platforms_not_supported:
         print_without_newline(
-            "XR platforms NOT supported: " + ", ".join(platforms_not_supported)
+            "\nXR platforms NOT supported: "
+            + ", ".join(sorted(platforms_not_supported))
         )
     if platforms_errored:
-        print_without_newline(f"\n{DASHED_LINE}")
         print_without_newline(
             "\n!! One or more platform checks could not be performed, see errors above !!"
         )
     # Print the result of any extra checks
     if extra_checks:
         print_without_newline(f"\n{DASHED_LINE}")
-    if extras_supported:
-        print_without_newline(
-            "\nExtra checks passed: " + ", ".join(extras_supported)
-        )
-    if extras_not_supported:
-        print_without_newline(
-            "\nExtra checks failed: " + ", ".join(extras_not_supported)
-        )
-    if any(c is CheckState.ERROR for c in extra_results.values()):
-        print_without_newline(
-            "\nExtra checks errored: " + ", ".join(extras_errored)
-        )
+        if extras_supported:
+            print_without_newline(
+                "\nExtra checks passed: " + ", ".join(sorted(extras_supported))
+            )
+        if extras_not_supported:
+            print_without_newline(
+                "\nExtra checks failed: "
+                + ", ".join(sorted(extras_not_supported))
+            )
+        if any(c is CheckState.ERROR for c in extra_results.values()):
+            print_without_newline(
+                "\nExtra checks errored: " + ", ".join(sorted(extras_errored))
+            )
     print(f"\n{DOUBLE_DASHED_LINE}")
 
     return len(platforms_supported) > 0

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1497,57 +1497,14 @@ def print_check_status_msg(
     print(colour(output))
 
 
-def print_summary_specific_platform(
-    result: OverallCheckState, platform: str
-) -> None:
-    if result is OverallCheckState.ERRORS:
-        summary = (
-            "!! One or more checks could not be performed, see errors above !!"
-        )
-    elif result is OverallCheckState.ALL_SUCCEEDED:
-        summary = f"Host environment set up correctly for {platform}"
-    elif result is OverallCheckState.FAILURES:
-        summary = f"!! Host NOT set up correctly for {platform} !!"
-    else:
-        assert False
-    print_without_newline(summary)
-
-
-def print_summary_all_platforms(
-    plats_supported: Set[str], plats_errored: Set[str]
-) -> None:
-    plats_not_supported = {
-        "xrd-control-plane",
-        "xrd-vrouter",
-    } - plats_supported
-
-    if plats_errored:
-        print_without_newline(
-            "!! One or more checks could not be performed, see errors above !!"
-        )
-    elif not plats_supported:
-        print_without_newline(
-            "!! Host NOT set up correctly for any XR platforms !!"
-        )
-    else:
-        print_without_newline(
-            "XR platforms supported: " + ", ".join(sorted(plats_supported))
-        )
-    if plats_not_supported and plats_supported:
-        print_without_newline(
-            "\nXR platforms NOT supported: "
-            + ", ".join(sorted(plats_not_supported))
-        )
-
-
-def perform_checks(checks: List[Check]) -> OverallCheckState:
+def perform_checks(checks: List[Check]) -> Mapping[str, CheckState]:
     """
     Perform host checks.
 
     :param checks:
         Checks to run through.
     :return:
-        The overall result of the checks.
+        A mapping of check names and the check state.
     """
     results: Dict[str, CheckState] = {}
     msg: Optional[str]
@@ -1572,59 +1529,7 @@ def perform_checks(checks: List[Check]) -> OverallCheckState:
 
         results[name] = status
 
-    return overall_check_state(results)
-
-
-def run_extra_checks(extra_checks: List[str]) -> Tuple[Set[str], Set[str]]:
-    """
-    Run the specified extra checks, printing the results and returning the
-    checks that succeeded and failed.
-
-    :param extra_checks:
-        List of extra checks to perform.
-
-    :returns:
-        Tuple of the checks that succeeded, and the checks that failed.
-
-    """
-    extras_supported = set()
-    extras_not_supported = set()
-
-    print("")  # insert a newline
-    print_heading("Extra checks")
-    for extra_check in sorted(extra_checks):
-        print_subheading(f"{extra_check} checks")
-        result = perform_checks(EXTRA_CHECKS_MAP[extra_check])
-        if result is OverallCheckState.ALL_SUCCEEDED:
-            extras_supported.add(extra_check)
-        else:
-            extras_not_supported.add(extra_check)
-
-    return extras_supported, extras_not_supported
-
-
-def print_extra_checks_summary(
-    supported: Set[str], not_supported: Set[str]
-) -> None:
-    """
-    Print a summary of the extra checks that passed and failed.
-
-    :param supported:
-        The checks that were successful.
-
-    :param not_supported:
-        The checks that were not successful.
-
-    """
-    print_without_newline(f"\n{DASHED_LINE}")
-    if supported:
-        print_without_newline(
-            "\nExtra checks passed: " + ", ".join(sorted(supported))
-        )
-    if not_supported:
-        print_without_newline(
-            "\nExtra checks failed: " + ", ".join(sorted(not_supported))
-        )
+    return results
 
 
 def run_checks_specific_platform(
@@ -1668,38 +1573,72 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
     """
     platforms_supported: Set[str] = set()
     platforms_not_supported: Set[str] = set()
-    platforms_with_errored_checks: Set[str] = set()
     extras_supported: Set[str] = set()
     extras_not_supported: Set[str] = set()
 
     print_heading("Platform checks")
     print_subheading("base checks")
-    base_result = perform_checks(BASE_CHECKS)
+    base_results = perform_checks(BASE_CHECKS)
     for platform, checks in PLATFORM_CHECKS_MAP.items():
         print_subheading(f"{platform} checks")
-        plat_result = perform_checks(checks)
+        plat_results = perform_checks(checks)
 
-        if OverallCheckState.ERRORS in [base_result, plat_result]:
-            platforms_with_errored_checks.add(platform)
-
-        if (
-            base_result is OverallCheckState.ALL_SUCCEEDED
-            and plat_result is OverallCheckState.ALL_SUCCEEDED
-        ):
-            platforms_supported.add(platform)
-        else:
+        if any(check.is_error() for check in base_results.values()):
             platforms_not_supported.add(platform)
+        elif any(check.is_error() for check in plat_results.values()):
+            platforms_not_supported.add(platform)
+        else:
+            platforms_supported.add(platform)
 
     if extra_checks:
-        extras_supported, extras_not_supported = run_extra_checks(extra_checks)
+        print("")  # insert a newline
+        print_heading("Extra checks")
+    for extra_check in sorted(extra_checks):
+        print_subheading(f"{extra_check} checks")
+        extra_results = perform_checks(EXTRA_CHECKS_MAP[extra_check])
 
+        if any(check.is_error() for check in extra_results.values()):
+            extras_not_supported.add(extra_check)
+        else:
+            extras_supported.add(extra_check)
+    # Print a summary of what is and is not supported
     print(f"\n{DOUBLE_DASHED_LINE}")
-    print_summary_all_platforms(
-        platforms_supported, platforms_with_errored_checks
-    )
+    if not platforms_supported:
+        print_without_newline(
+            "!! Host NOT set up correctly for any XR platforms !!"
+        )
+    else:
+        print_without_newline(
+            "XR platforms supported: " + ", ".join(platforms_supported)
+        )
+    if platforms_not_supported:
+        print_without_newline(
+            "XR platforms NOT supported: " + ", ".join(platforms_not_supported)
+        )
+    # Print the result of any extra checks
     if extra_checks:
-        print_extra_checks_summary(extras_supported, extras_not_supported)
-    print(f"\n{DOUBLE_DASHED_LINE}")
+        print_without_newline(f"\n{DASHED_LINE}")
+    if extras_supported:
+        print_without_newline(
+            "Extra checks passed: " + ", ".join(extras_supported)
+        )
+    if extras_not_supported:
+        print_without_newline(
+            "Extra checks failed: " + ", ".join(extras_not_supported)
+        )
+    # Check if there were any errors
+    nested_results_list = [base_results, plat_results]
+    if extra_checks:
+        nested_results_list += [extra_results]
+    all_results = [list(results.values()) for results in nested_results_list]
+    flat_results = [
+        results for results_list in all_results for results in results_list
+    ]
+    if any(check_result.is_error() for check_result in flat_results):
+        print_without_newline(f"\n{DASHED_LINE}")
+        print_without_newline(
+            "!! One or more checks could not be performed, see errors above !!"
+        )
 
     return len(platforms_supported) > 0
 

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -325,12 +325,11 @@ class CheckState(enum.Enum):
     ERROR = "error"  # Check state for when the check fails to run/errors
     NEUTRAL = "neutral"
 
-    def is_error(self) -> bool:
+    def is_failure(self) -> bool:
         return self in [
             CheckState.FAILED,
             CheckState.SKIPPED,
             CheckState.WARNING,
-            CheckState.ERROR,
         ]
 
 
@@ -351,7 +350,7 @@ def overall_check_state(results: Dict[str, CheckState]) -> OverallCheckState:
     :return:
         The overall check state.
     """
-    success = not any(c.is_error() for c in results.values())
+    success = not any(c.is_failure() for c in results.values())
     errored_checks = any(c is CheckState.ERROR for c in results.values())
     if success:
         return OverallCheckState.ALL_SUCCEEDED
@@ -1511,7 +1510,7 @@ def perform_checks(checks: List[Check]) -> Mapping[str, CheckState]:
 
     for name, check_fn, deps in checks:
         # Only run this test if previous dependent tests were successful.
-        if not any(results[dep].is_error() for dep in deps):
+        if not any(results[dep].is_failure() for dep in deps):
             try:
                 ret = check_fn()
                 if ret:
@@ -1573,8 +1572,10 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
     """
     platforms_supported: Set[str] = set()
     platforms_not_supported: Set[str] = set()
+    platforms_errored: Set[str] = set()
     extras_supported: Set[str] = set()
     extras_not_supported: Set[str] = set()
+    extras_errored: Set[str] = set()
 
     print_heading("Platform checks")
     print_subheading("base checks")
@@ -1582,32 +1583,33 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
     for platform, checks in PLATFORM_CHECKS_MAP.items():
         print_subheading(f"{platform} checks")
         plat_results = perform_checks(checks)
-
-        if any(check.is_error() for check in base_results.values()):
+        b_and_p_results = list(base_results.values()) + list(
+            plat_results.values()
+        )
+        if any(result.is_failure() for result in b_and_p_results):
             platforms_not_supported.add(platform)
-        elif any(check.is_error() for check in plat_results.values()):
-            platforms_not_supported.add(platform)
+        elif any(result is CheckState.ERROR for result in b_and_p_results):
+            platforms_errored.add(platform)
         else:
             platforms_supported.add(platform)
 
     if extra_checks:
         print("")  # insert a newline
         print_heading("Extra checks")
-    for extra_check in sorted(extra_checks):
-        print_subheading(f"{extra_check} checks")
-        extra_results = perform_checks(EXTRA_CHECKS_MAP[extra_check])
+        for extra_check in sorted(extra_checks):
+            print_subheading(f"{extra_check} checks")
+            extra_results = perform_checks(EXTRA_CHECKS_MAP[extra_check])
 
-        if any(check.is_error() for check in extra_results.values()):
-            extras_not_supported.add(extra_check)
-        else:
-            extras_supported.add(extra_check)
+            if any(check.is_failure() for check in extra_results.values()):
+                extras_not_supported.add(extra_check)
+            elif any(c is CheckState.ERROR for c in extra_results.values()):
+                extras_errored.add(extra_check)
+            else:
+                extras_supported.add(extra_check)
+
     # Print a summary of what is and is not supported
     print(f"\n{DOUBLE_DASHED_LINE}")
-    if not platforms_supported:
-        print_without_newline(
-            "!! Host NOT set up correctly for any XR platforms !!"
-        )
-    else:
+    if platforms_supported:
         print_without_newline(
             "XR platforms supported: " + ", ".join(platforms_supported)
         )
@@ -1615,30 +1617,27 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
         print_without_newline(
             "XR platforms NOT supported: " + ", ".join(platforms_not_supported)
         )
+    if platforms_errored:
+        print_without_newline(f"\n{DASHED_LINE}")
+        print_without_newline(
+            "\n!! One or more platform checks could not be performed, see errors above !!"
+        )
     # Print the result of any extra checks
     if extra_checks:
         print_without_newline(f"\n{DASHED_LINE}")
     if extras_supported:
         print_without_newline(
-            "Extra checks passed: " + ", ".join(extras_supported)
+            "\nExtra checks passed: " + ", ".join(extras_supported)
         )
     if extras_not_supported:
         print_without_newline(
-            "Extra checks failed: " + ", ".join(extras_not_supported)
+            "\nExtra checks failed: " + ", ".join(extras_not_supported)
         )
-    # Check if there were any errors
-    nested_results_list = [base_results, plat_results]
-    if extra_checks:
-        nested_results_list += [extra_results]
-    all_results = [list(results.values()) for results in nested_results_list]
-    flat_results = [
-        results for results_list in all_results for results in results_list
-    ]
-    if any(check_result.is_error() for check_result in flat_results):
-        print_without_newline(f"\n{DASHED_LINE}")
+    if any(c is CheckState.ERROR for c in extra_results.values()):
         print_without_newline(
-            "!! One or more checks could not be performed, see errors above !!"
+            "\nExtra checks errored: " + ", ".join(extras_errored)
         )
+    print(f"\n{DOUBLE_DASHED_LINE}")
 
     return len(platforms_supported) > 0
 

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -341,9 +341,6 @@ class OverallCheckState(enum.Enum):
     FAILURES = "failures"
     ERRORS = "errors"
 
-    def is_success(self) -> bool:
-        return self is OverallCheckState.ALL_SUCCEEDED
-
 
 def overall_check_state(results: Dict[str, CheckState]) -> OverallCheckState:
     """
@@ -358,10 +355,10 @@ def overall_check_state(results: Dict[str, CheckState]) -> OverallCheckState:
     errored_checks = any(c is CheckState.ERROR for c in results.values())
     if success:
         return OverallCheckState.ALL_SUCCEEDED
-    if errored_checks:
-        return OverallCheckState.ERRORS
-    else:
+    elif not success and not errored_checks:
         return OverallCheckState.FAILURES
+    else:
+        return OverallCheckState.ERRORS
 
 
 CheckFuncReturn = Optional[Tuple[CheckState, str]]
@@ -429,15 +426,16 @@ def check_cpu_cores() -> CheckFuncReturn:
 
 def check_kernel_version() -> CheckFuncReturn:
     """Check kernel version is recent enough."""
+    cmd = "uname -r"
     try:
-        output, _ = run_cmd(["uname", "-r"])
+        output, _ = run_cmd(shlex.split(cmd))
         version = ".".join(output.strip().split(".")[:2])
         version_tuple = tuple(int(x) for x in version.split("."))
 
     except Exception:
         return (
             CheckState.ERROR,
-            "Unable to check the kernel version - must be at least version 4.0",
+            f"Unable to check the kernel version with command {cmd!r} - must be at least version 4.0",
         )
 
     if version_tuple < (4, 0):
@@ -489,7 +487,7 @@ def check_cgroups() -> CheckFuncReturn:
         version = _get_cgroup_version()
     except Exception:
         return (
-            CheckState.FAILED,
+            CheckState.ERROR,
             "Error trying to determine the cgroups version - /sys/fs/cgroup is expected to\n"
             "contain cgroup v1 mounts.",
         )
@@ -1286,7 +1284,7 @@ def check_supports_d_type() -> CheckFuncReturn:
         output = run_cmd(shlex.split(cmd))[0]
     except subprocess.SubprocessError:
         return (
-            CheckState.FAILED,
+            CheckState.ERROR,
             f"{cmd!r} command failed.\n"
             f"Unable to check filesystem support for d_type (directory entry type).\n"
             f"This is required for XRd to avoid issues with creating and deleting files.",
@@ -1564,12 +1562,9 @@ def perform_checks(checks: List[Check]) -> OverallCheckState:
                 else:
                     status = CheckState.SUCCESS
                     msg = None
-            except CmdTimeoutError as e:
+            except (CmdTimeoutError, Exception) as e:
                 status = CheckState.ERROR
-                msg = f"Unexpected error: {e}"
-            except Exception as e:
-                status = CheckState.FAILED
-                msg = f"Unexpected error: {e}"
+                msg = f"Command timed out: {e}"
         else:
             status = CheckState.SKIPPED
             msg = "Skipped due to failed checks: {}".format(", ".join(deps))
@@ -1600,7 +1595,7 @@ def run_extra_checks(extra_checks: List[str]) -> Tuple[Set[str], Set[str]]:
     for extra_check in sorted(extra_checks):
         print_subheading(f"{extra_check} checks")
         result = perform_checks(EXTRA_CHECKS_MAP[extra_check])
-        if result.is_success():
+        if result is OverallCheckState.ALL_SUCCEEDED:
             extras_supported.add(extra_check)
         else:
             extras_not_supported.add(extra_check)
@@ -1659,7 +1654,9 @@ def run_checks_specific_platform(
         print_extra_checks_summary(extras_supported, extras_not_supported)
     print(f"\n{DOUBLE_DASHED_LINE}")
 
-    return result.is_success() and not extras_not_supported
+    return (
+        result is OverallCheckState.ALL_SUCCEEDED and not extras_not_supported
+    )
 
 
 def run_checks_all_platforms(extra_checks: List[str]) -> bool:
@@ -1685,7 +1682,10 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
         if OverallCheckState.ERRORS in [base_result, plat_result]:
             platforms_with_errored_checks.add(platform)
 
-        if base_result.is_success() and plat_result.is_success():
+        if (
+            base_result is OverallCheckState.ALL_SUCCEEDED
+            and plat_result is OverallCheckState.ALL_SUCCEEDED
+        ):
             platforms_supported.add(platform)
         else:
             platforms_not_supported.add(platform)

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1492,9 +1492,12 @@ def perform_checks(checks: List[Check]) -> Mapping[str, CheckState]:
                 else:
                     status = CheckState.SUCCESS
                     msg = None
-            except (CmdTimeoutError, Exception) as e:
+            except CmdTimeoutError as e:
                 status = CheckState.ERROR
                 msg = f"Command timed out: {e}"
+            except Exception as e:
+                status = CheckState.ERROR
+                msg = f"Unexpected error: {e}"
         else:
             status = CheckState.SKIPPED
             msg = "Skipped due to failed checks: {}".format(", ".join(deps))

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1545,22 +1545,59 @@ def run_checks_specific_platform(
     :return:
         Whether all checks that were performed succeeded.
     """
+    extras_supported: Set[str] = set()
     extras_not_supported: Set[str] = set()
+    extras_errored: Set[str] = set()
+
     print_heading(f"Platform checks - {platform}")
-    result = perform_checks(BASE_CHECKS + PLATFORM_CHECKS_MAP[platform])
+    plat_results = perform_checks(BASE_CHECKS + PLATFORM_CHECKS_MAP[platform])
+    plat_failure = any(check.is_failure() for check in plat_results.values())
+    plat_error = any(c is CheckState.ERROR for c in plat_results.values())
 
-    if extra_checks is not None:  # check if any extra checks were specified
-        extras_supported, extras_not_supported = run_extra_checks(extra_checks)
+    if extra_checks:
+        print("")  # insert a newline
+        print_heading("Extra checks")
+        for extra_check in sorted(extra_checks):
+            print_subheading(f"{extra_check} checks")
+            extra_results = perform_checks(EXTRA_CHECKS_MAP[extra_check])
 
+            if any(check.is_failure() for check in extra_results.values()):
+                extras_not_supported.add(extra_check)
+            elif any(c is CheckState.ERROR for c in extra_results.values()):
+                extras_errored.add(extra_check)
+            else:
+                extras_supported.add(extra_check)
+
+    # Print a summary of what is and is not supported
+    print_without_newline(f"\n{DOUBLE_DASHED_LINE}")
+    if plat_failure:
+        print_without_newline(
+            f"\n!! Host not set up correctly for {platform} !!"
+        )
+    elif plat_error:
+        print_without_newline(
+            "\n!! One or more platform checks could not be performed, see errors above !!"
+        )
+    else:
+        print_without_newline(f"\nHost is set up correctly for {platform} :D")
+    # Print the result of any extra checks
+    if extra_checks:
+        print_without_newline(f"\n{DASHED_LINE}")
+        if extras_supported:
+            print_without_newline(
+                "\nExtra checks passed: " + ", ".join(extras_supported)
+            )
+        if extras_not_supported:
+            print_without_newline(
+                "\nExtra checks failed: " + ", ".join(extras_not_supported)
+            )
+        if any(c is CheckState.ERROR for c in extra_results.values()):
+            print_without_newline(
+                "\nExtra checks errored: " + ", ".join(extras_errored)
+            )
     print(f"\n{DOUBLE_DASHED_LINE}")
-    print_summary_specific_platform(result, platform)
-    if extra_checks is not None:
-        print_extra_checks_summary(extras_supported, extras_not_supported)
-    print(f"\n{DOUBLE_DASHED_LINE}")
 
-    return (
-        result is OverallCheckState.ALL_SUCCEEDED and not extras_not_supported
-    )
+    return not (plat_failure or plat_error)
 
 
 def run_checks_all_platforms(extra_checks: List[str]) -> bool:

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -334,33 +334,6 @@ class CheckState(enum.Enum):
         return self in [CheckState.SUCCESS, CheckState.NEUTRAL]
 
 
-class OverallCheckState(enum.Enum):
-    """The overall result state of multiple checks."""
-
-    ALL_SUCCEEDED = "all succeeded"
-    FAILURES = "failures"
-    ERRORS = "errors"
-
-
-def overall_check_state(results: Dict[str, CheckState]) -> OverallCheckState:
-    """
-    Determine the overall check state for the given results.
-
-    :param results:
-        Dictionary of results.
-    :return:
-        The overall check state.
-    """
-    success = not any(c.is_failure() for c in results.values())
-    errored_checks = any(c is CheckState.ERROR for c in results.values())
-    if success:
-        return OverallCheckState.ALL_SUCCEEDED
-    elif not success and not errored_checks:
-        return OverallCheckState.FAILURES
-    else:
-        return OverallCheckState.ERRORS
-
-
 CheckFuncReturn = Optional[Tuple[CheckState, str]]
 
 

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -485,6 +485,45 @@ Extra checks passed: docker, xr-compose
         assert textwrap.dedent(output) == cli_output
         assert exit_code == 0
 
+    def test_extra_check_erroring(self, capsys):
+        """Test running host-check with the docker extra check erroring."""
+        exit_code, output = self.run_host_check(
+            capsys, ["-e", "docker"], erroring_checks=["Docker daemon"]
+        )
+        cli_output = f"""\
+==============================
+Platform checks
+==============================
+
+base checks
+-----------------------
+Checks: {BASE_CHECKS_STR}
+
+xrd-control-plane checks
+-----------------------
+Checks: RAM
+
+xrd-vrouter checks
+-----------------------
+Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size, Real-time Group Scheduling
+
+==============================
+Extra checks
+==============================
+
+docker checks
+-----------------------
+Checks: Docker client, Docker daemon, Docker supports d_type
+
+============================================================================
+XR platforms supported: xrd-control-plane, xrd-vrouter
+----------------------------------------------------------------------------
+Extra checks errored: docker
+============================================================================
+"""
+        assert textwrap.dedent(output) == cli_output
+        assert exit_code == 0
+
     def test_plat_specified_check_failing(self, capsys):
         """Test a platform check failing when host-check is run with arguments."""
         exit_code, output = self.run_host_check(
@@ -689,6 +728,41 @@ Host environment set up correctly for xrd-control-plane
 ----------------------------------------------------------------------------
 Extra checks passed: docker
 Extra checks failed: xr-compose
+============================================================================
+"""
+        assert textwrap.dedent(output) == cli_output
+        assert exit_code == 1
+
+    def test_extra_check_erroring_plat(self, capsys):
+        """Test a specified extra check erroring."""
+        exit_code, output = self.run_host_check(
+            capsys,
+            ["-p", "xrd-control-plane", "-e", "docker", "xr-compose"],
+            erroring_checks=["PyYAML"],
+        )
+        cli_output = f"""\
+==============================
+Platform checks - xrd-control-plane
+==============================
+Checks: {CONTROL_PLANE_CHECKS_STR}
+
+==============================
+Extra checks
+==============================
+
+docker checks
+-----------------------
+Checks: Docker client, Docker daemon, Docker supports d_type
+
+xr-compose checks
+-----------------------
+Checks: docker-compose, PyYAML, Bridge iptables
+
+============================================================================
+Host environment set up correctly for xrd-control-plane
+----------------------------------------------------------------------------
+Extra checks passed: docker
+Extra checks errored: xr-compose
 ============================================================================
 """
         assert textwrap.dedent(output) == cli_output

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -251,7 +251,7 @@ XR platforms supported: xrd-control-plane, xrd-vrouter
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {BASE_CHECKS_STR} {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR}, {CONTROL_PLANE_CHECKS_STR}
 
 ============================================================================
 Host environment set up correctly for xrd-control-plane
@@ -267,7 +267,7 @@ Host environment set up correctly for xrd-control-plane
 ==============================
 Platform checks - xrd-vrouter
 ==============================
-Checks: {BASE_CHECKS_STR} {VROUTER_CHECKS_STR}
+Checks: {BASE_CHECKS_STR}, {VROUTER_CHECKS_STR}
 
 ============================================================================
 Host environment set up correctly for xrd-vrouter
@@ -285,7 +285,7 @@ Host environment set up correctly for xrd-vrouter
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR}, {CONTROL_PLANE_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -313,7 +313,7 @@ Extra checks passed: docker
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR}, {CONTROL_PLANE_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -341,7 +341,7 @@ Extra checks passed: xr-compose
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR}, {CONTROL_PLANE_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -531,7 +531,7 @@ Extra checks errored: docker
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR}, {CONTROL_PLANE_CHECKS_STR}
 
 ============================================================================
 !! Host NOT set up correctly for xrd-control-plane !!
@@ -551,7 +551,7 @@ Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR}, {CONTROL_PLANE_CHECKS_STR}
 
 ============================================================================
 !! One or more platform checks could not be performed, see errors above !!
@@ -705,7 +705,7 @@ Extra checks failed: xr-compose
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR}, {CONTROL_PLANE_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -740,7 +740,7 @@ Extra checks failed: xr-compose
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR}, {CONTROL_PLANE_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -953,7 +953,7 @@ class TestCPUCores(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- CPU cores
-                     Command timed out: Timed out while executing command: {" ".join(self.cmds)}
+                     Unexpected error: Timed out while executing command: {" ".join(self.cmds)}
             """
         )
         assert result is CheckState.ERROR
@@ -1115,7 +1115,7 @@ class TestBaseKernelModules(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- Base kernel modules
-                     Command timed out: Timed out while executing command: {" ".join(self.cmds)}
+                     Unexpected error: Timed out while executing command: {" ".join(self.cmds)}
             """
         )
         assert result is CheckState.ERROR
@@ -1342,7 +1342,7 @@ class _TestInotifyLimitsBase(_CheckTestBase):
                       sysctl -w fs.inotify.{self.inotify_param}=64000
             """
         )
-        assert result is CheckState.FAILED
+        assert result is CheckState.WARNING
 
     def test_error(self, capsys):
         """Test error being raised."""

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -943,7 +943,7 @@ class TestCPUCores(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- CPU cores
-                     Command timed out: test exception
+                     Unexpected error: test exception
             """
         )
         assert result is CheckState.ERROR
@@ -1105,7 +1105,7 @@ class TestBaseKernelModules(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- Base kernel modules
-                     Command timed out: test exception
+                     Unexpected error: test exception
             """
         )
         assert result is CheckState.ERROR
@@ -2021,7 +2021,7 @@ Swap:   31798079488  2008911872 29789167616
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- RAM
-                     Command timed out: test exception
+                     Unexpected error: test exception
             """
         )
         assert result is CheckState.ERROR
@@ -2093,7 +2093,7 @@ class TestCPUExtensions(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- CPU extensions
-                     Command timed out: test exception
+                     Unexpected error: test exception
             """
         )
         assert result is CheckState.ERROR
@@ -2274,7 +2274,7 @@ class TestHugepages(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Hugepages
-                     Command timed out: test exception
+                     Unexpected error: test exception
             """
         )
         assert result is CheckState.ERROR
@@ -2455,7 +2455,7 @@ class TestGDPKernelDriver(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- Interface kernel driver
-                     Command timed out: test exception
+                     Unexpected error: test exception
             """
         )
         assert result is CheckState.ERROR
@@ -2737,7 +2737,7 @@ pci@0000:00:01.0  device2     network    Ethernet interface
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- IOMMU
-                     Command timed out: test exception
+                     Unexpected error: test exception
             """
         )
         assert result is CheckState.ERROR
@@ -2850,7 +2850,7 @@ class TestSharedMemPageMaxSize(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Shared memory pages max size
-                     Command timed out: test exception
+                     Unexpected error: test exception
             """
         )
         assert result is CheckState.ERROR
@@ -2931,7 +2931,7 @@ class TestDockerClient(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Docker client
-                     Command timed out: test exception
+                     Unexpected error: test exception
             """
         )
         assert result is CheckState.ERROR
@@ -3005,7 +3005,7 @@ class TestDockerDaemon(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Docker daemon
-                     Command timed out: test exception
+                     Unexpected error: test exception
             """
         )
         assert result is CheckState.ERROR
@@ -3076,7 +3076,7 @@ class TestDtypeSupport(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Docker supports d_type
-                     Command timed out: test exception
+                     Unexpected error: test exception
             """
         )
         assert result is CheckState.ERROR
@@ -3166,7 +3166,7 @@ class TestDockerCompose(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- docker-compose
-                     Command timed out: test exception
+                     Unexpected error: test exception
             """
         )
         assert result is CheckState.ERROR
@@ -3207,7 +3207,7 @@ class TestPyYAML(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- PyYAML
-                     Command timed out: test exception
+                     Unexpected error: test exception
             """
         )
         assert result is CheckState.ERROR

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -45,17 +45,13 @@ CHECKS_BY_GROUP = {
 }
 
 
-def _checks_to_str(checks: List[host_check.Check]) -> str:  # ignore
+def _checks_to_str(checks: List[host_check.Check]) -> str:
     return ", ".join(check.name for check in checks)
 
 
 BASE_CHECKS_STR = _checks_to_str(host_check.BASE_CHECKS)
-CONTROL_PLANE_CHECKS_STR = _checks_to_str(
-    host_check.BASE_CHECKS + host_check.CONTROL_PLANE_CHECKS
-)
-VROUTER_CHECKS_STR = _checks_to_str(
-    host_check.BASE_CHECKS + host_check.VROUTER_CHECKS
-)
+CONTROL_PLANE_CHECKS_STR = _checks_to_str(host_check.CONTROL_PLANE_CHECKS)
+VROUTER_CHECKS_STR = _checks_to_str(host_check.VROUTER_CHECKS)
 
 
 def perform_check(
@@ -233,17 +229,17 @@ Checks: {BASE_CHECKS_STR}
 
 xrd-control-plane checks
 -----------------------
-Checks: RAM
+Checks: {CONTROL_PLANE_CHECKS_STR}
 
 xrd-vrouter checks
 -----------------------
-Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size, Real-time Group Scheduling
+Checks: {VROUTER_CHECKS_STR}
 
 ============================================================================
 XR platforms supported: xrd-control-plane, xrd-vrouter
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 0
 
     def test_plat_xrd(self, capsys):
@@ -255,13 +251,13 @@ XR platforms supported: xrd-control-plane, xrd-vrouter
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR} {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
 
 ============================================================================
 Host environment set up correctly for xrd-control-plane
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 0
 
     def test_plat_xrd_vrouter(self, capsys):
@@ -271,13 +267,13 @@ Host environment set up correctly for xrd-control-plane
 ==============================
 Platform checks - xrd-vrouter
 ==============================
-Checks: {VROUTER_CHECKS_STR}
+Checks: {BASE_CHECKS_STR} {VROUTER_CHECKS_STR}
 
 ============================================================================
 Host environment set up correctly for xrd-vrouter
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 0
 
     def test_extra_check_docker_plat(self, capsys):
@@ -289,7 +285,7 @@ Host environment set up correctly for xrd-vrouter
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -305,7 +301,7 @@ Host environment set up correctly for xrd-control-plane
 Extra checks passed: docker
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 0
 
     def test_extra_check_xr_compose_plat(self, capsys):
@@ -317,7 +313,7 @@ Extra checks passed: docker
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -333,7 +329,7 @@ Host environment set up correctly for xrd-control-plane
 Extra checks passed: xr-compose
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 0
 
     def test_all_extra_checks_plat(self, capsys):
@@ -345,7 +341,7 @@ Extra checks passed: xr-compose
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -365,7 +361,7 @@ Host environment set up correctly for xrd-control-plane
 Extra checks passed: docker, xr-compose
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 0
 
     def test_extra_check_docker(self, capsys):
@@ -382,11 +378,11 @@ Checks: {BASE_CHECKS_STR}
 
 xrd-control-plane checks
 -----------------------
-Checks: RAM
+Checks: {CONTROL_PLANE_CHECKS_STR}
 
 xrd-vrouter checks
 -----------------------
-Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size, Real-time Group Scheduling
+Checks: {VROUTER_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -402,7 +398,7 @@ XR platforms supported: xrd-control-plane, xrd-vrouter
 Extra checks passed: docker
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 0
 
     def test_extra_check_xr_compose(self, capsys):
@@ -419,11 +415,11 @@ Checks: {BASE_CHECKS_STR}
 
 xrd-control-plane checks
 -----------------------
-Checks: RAM
+Checks: {CONTROL_PLANE_CHECKS_STR}
 
 xrd-vrouter checks
 -----------------------
-Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size, Real-time Group Scheduling
+Checks: {VROUTER_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -439,7 +435,7 @@ XR platforms supported: xrd-control-plane, xrd-vrouter
 Extra checks passed: xr-compose
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 0
 
     def test_all_extra_checks(self, capsys):
@@ -458,11 +454,11 @@ Checks: {BASE_CHECKS_STR}
 
 xrd-control-plane checks
 -----------------------
-Checks: RAM
+Checks: {CONTROL_PLANE_CHECKS_STR}
 
 xrd-vrouter checks
 -----------------------
-Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size, Real-time Group Scheduling
+Checks: {VROUTER_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -482,7 +478,7 @@ XR platforms supported: xrd-control-plane, xrd-vrouter
 Extra checks passed: docker, xr-compose
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 0
 
     def test_extra_check_erroring(self, capsys):
@@ -501,11 +497,11 @@ Checks: {BASE_CHECKS_STR}
 
 xrd-control-plane checks
 -----------------------
-Checks: RAM
+Checks: {CONTROL_PLANE_CHECKS_STR}
 
 xrd-vrouter checks
 -----------------------
-Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size, Real-time Group Scheduling
+Checks: {VROUTER_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -521,7 +517,7 @@ XR platforms supported: xrd-control-plane, xrd-vrouter
 Extra checks errored: docker
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 0
 
     def test_plat_specified_check_failing(self, capsys):
@@ -535,13 +531,13 @@ Extra checks errored: docker
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
 
 ============================================================================
 !! Host NOT set up correctly for xrd-control-plane !!
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 1
 
     def test_plat_specified_check_erroring(self, capsys):
@@ -555,13 +551,13 @@ Checks: {CONTROL_PLANE_CHECKS_STR}
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
 
 ============================================================================
 !! One or more platform checks could not be performed, see errors above !!
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 1
 
     def test_base_check_erroring(self, capsys):
@@ -582,17 +578,17 @@ Checks: {BASE_CHECKS_STR}
 
 xrd-control-plane checks
 -----------------------
-Checks: RAM
+Checks: {CONTROL_PLANE_CHECKS_STR}
 
 xrd-vrouter checks
 -----------------------
-Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size, Real-time Group Scheduling
+Checks: {VROUTER_CHECKS_STR}
 
 ============================================================================
 !! One or more platform checks could not be performed, see errors above !!
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 1
 
     def test_no_plats_supported(self, capsys):
@@ -611,17 +607,17 @@ Checks: {BASE_CHECKS_STR}
 
 xrd-control-plane checks
 -----------------------
-Checks: RAM
+Checks: {CONTROL_PLANE_CHECKS_STR}
 
 xrd-vrouter checks
 -----------------------
-Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size, Real-time Group Scheduling
+Checks: {VROUTER_CHECKS_STR}
 
 ============================================================================
 XR platforms NOT supported: xrd-control-plane, xrd-vrouter
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 1
 
     def test_one_plat_supported(self, capsys):
@@ -640,18 +636,18 @@ Checks: {BASE_CHECKS_STR}
 
 xrd-control-plane checks
 -----------------------
-Checks: RAM
+Checks: {CONTROL_PLANE_CHECKS_STR}
 
 xrd-vrouter checks
 -----------------------
-Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size, Real-time Group Scheduling
+Checks: {VROUTER_CHECKS_STR}
 
 ============================================================================
 XR platforms supported: xrd-control-plane
 XR platforms NOT supported: xrd-vrouter
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 0
 
     def test_extra_check_not_supported(self, capsys):
@@ -670,11 +666,11 @@ Checks: {BASE_CHECKS_STR}
 
 xrd-control-plane checks
 -----------------------
-Checks: RAM
+Checks: {CONTROL_PLANE_CHECKS_STR}
 
 xrd-vrouter checks
 -----------------------
-Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared memory pages max size, Real-time Group Scheduling
+Checks: {VROUTER_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -695,7 +691,7 @@ Extra checks passed: docker
 Extra checks failed: xr-compose
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 0
 
     def test_extra_check_failing(self, capsys):
@@ -709,7 +705,7 @@ Extra checks failed: xr-compose
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -730,7 +726,7 @@ Extra checks passed: docker
 Extra checks failed: xr-compose
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 1
 
     def test_extra_check_erroring_plat(self, capsys):
@@ -744,7 +740,7 @@ Extra checks failed: xr-compose
 ==============================
 Platform checks - xrd-control-plane
 ==============================
-Checks: {CONTROL_PLANE_CHECKS_STR}
+Checks: {BASE_CHECKS_STR} {CONTROL_PLANE_CHECKS_STR}
 
 ==============================
 Extra checks
@@ -765,7 +761,7 @@ Extra checks passed: docker
 Extra checks errored: xr-compose
 ============================================================================
 """
-        assert textwrap.dedent(output) == cli_output
+        assert output == cli_output
         assert exit_code == 1
 
     def test_unrecognized_arg(self, capsys):
@@ -853,18 +849,18 @@ class TestArch(_CheckTestBase):
         """Test the architecture being correct."""
         result, output = self.perform_check(capsys, cmd_effects="x86_64")
         assert textwrap.dedent(output) == "PASS -- CPU architecture (x86_64)\n"
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_incorrect_arch(self, capsys):
         """Test the incorrect architecture case."""
         result, output = self.perform_check(capsys, cmd_effects="arm64")
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             FAIL -- CPU architecture
-                     The CPU architecture is arm64, but XRd only supports: x86_64.
+            FAIL -- CPU architecture
+                    The CPU architecture is arm64, but XRd only supports: x86_64.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_subproc_error(self, capsys):
         """Test a subprocess error being raised."""
@@ -892,19 +888,19 @@ class TestCPUCores(_CheckTestBase):
         """Test the success case."""
         result, output = self.perform_check(capsys, cmd_effects="CPU(s): 16 ")
         assert textwrap.dedent(output) == f"PASS -- CPU cores (16)\n"
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_too_few_cpus(self, capsys):
         """Test there being too few available CPU cores."""
         result, output = self.perform_check(capsys, cmd_effects="CPU(s): 1 ")
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             FAIL -- CPU cores
-                     The number of available CPU cores is 1,
-                     but at least 2 CPU cores are required.
+            FAIL -- CPU cores
+                    The number of available CPU cores is 1,
+                    but at least 2 CPU cores are required.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_parse_error(self, capsys):
         """Test error when parsing output from 'lscpu'."""
@@ -974,7 +970,7 @@ class TestKernelVersion(_CheckTestBase):
         """Test the success case."""
         result, output = self.perform_check(capsys, cmd_effects="4.1")
         assert textwrap.dedent(output) == "PASS -- Kernel version (4.1)\n"
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_subproc_error(self, capsys):
         """Test a subprocess error being raised."""
@@ -1007,11 +1003,11 @@ class TestKernelVersion(_CheckTestBase):
         result, output = self.perform_check(capsys, cmd_effects="3.9.8")
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Kernel version
-                     The kernel version is 3.9, but at least version 4.0 is required.
+            FAIL -- Kernel version
+                    The kernel version is 3.9, but at least version 4.0 is required.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_rhel83_version(self, capsys):
         """Test the version being 4.18.0-240 on RHEL/CentOS 8.3."""
@@ -1020,13 +1016,13 @@ class TestKernelVersion(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Kernel version
-                     The operating system appears to be RHEL/CentOS 8.3 (kernel version 4.18.0-240),
-                     which is not supported due to a kernel bug.
-                     Please upgrade/downgrade to a RHEL/CentOS version higher or lower than 8.3
+            FAIL -- Kernel version
+                    The operating system appears to be RHEL/CentOS 8.3 (kernel version 4.18.0-240),
+                    which is not supported due to a kernel bug.
+                    Please upgrade/downgrade to a RHEL/CentOS version higher or lower than 8.3
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_rhel82_version(self, capsys):
         """Test the version being 4.18.0-193 on RHEL/CentOS 8.2."""
@@ -1034,7 +1030,7 @@ class TestKernelVersion(_CheckTestBase):
             capsys, cmd_effects="4.18.0-193.el8"
         )
         assert textwrap.dedent(output) == "PASS -- Kernel version (4.18)\n"
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_generic_os_with_rhel83_kernel_version(self, capsys):
         """Test the version being 4.18.0-240 on a generic operating system."""
@@ -1042,7 +1038,7 @@ class TestKernelVersion(_CheckTestBase):
             capsys, cmd_effects="4.18.0-240.generic"
         )
         assert textwrap.dedent(output) == "PASS -- Kernel version (4.18)\n"
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
 
 class TestBaseKernelModules(_CheckTestBase):
@@ -1061,11 +1057,11 @@ class TestBaseKernelModules(_CheckTestBase):
         result, output = self.perform_check(capsys, cmd_effects=["", ""])
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             PASS -- Base kernel modules
-                     Installed module(s): dummy, nf_tables
+            PASS -- Base kernel modules
+                    Installed module(s): dummy, nf_tables
             """
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_missing_nf_tables(self, capsys):
         """Test missing the nf_tables kernel module."""
@@ -1074,13 +1070,13 @@ class TestBaseKernelModules(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             FAIL -- Base kernel modules
-                     Missing kernel module(s): nf_tables
-                     (checked in /lib/modules/*/modules.*).
-                     It may be possible to install using your distro's package manager.
+            FAIL -- Base kernel modules
+                    Missing kernel module(s): nf_tables
+                    (checked in /lib/modules/*/modules.*).
+                    It may be possible to install using your distro's package manager.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_missing_dummy(self, capsys):
         """Test missing the dummy kernel module."""
@@ -1089,13 +1085,13 @@ class TestBaseKernelModules(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             FAIL -- Base kernel modules
-                     Missing kernel module(s): dummy
-                     (checked in /lib/modules/*/modules.*).
-                     It may be possible to install using your distro's package manager.
+            FAIL -- Base kernel modules
+                    Missing kernel module(s): dummy
+                    (checked in /lib/modules/*/modules.*).
+                    It may be possible to install using your distro's package manager.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_unexpected_error(self, capsys):
         """Test unexpected error being raised."""
@@ -1129,11 +1125,11 @@ class TestBaseKernelModules(_CheckTestBase):
         result, output = self.perform_check(capsys, failed_deps=self.deps)
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             SKIP -- Base kernel modules
-                     Skipped due to failed checks: Kernel version
+            SKIP -- Base kernel modules
+                    Skipped due to failed checks: Kernel version
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.SKIPPED
 
 
 class TestCgroups(_CheckTestBase):
@@ -1176,7 +1172,7 @@ class TestCgroups(_CheckTestBase):
             PASS -- Cgroups (v1)
             """
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_unknown_version(self, capsys):
         """Test the case where the cgroups version is unrecognised."""
@@ -1201,11 +1197,11 @@ class TestCgroups(_CheckTestBase):
             )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             INFO -- Cgroups
-                     Cgroups v2 is in use - this is not supported for production environments.
+            INFO -- Cgroups
+                    Cgroups v2 is in use - this is not supported for production environments.
             """
         )
-        assert result.is_success()
+        assert result is CheckState.NEUTRAL
 
     def test_subproc_error(self, capsys):
         """Test a subprocess error being raised."""
@@ -1237,15 +1233,15 @@ class TestCgroups(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Cgroups
-                     These cgroup mounts do not exist on the host: systemd.
-                     These mounts are required to run XRd.
-                     If your distro doesn't use systemd, manually add the systemd cgroup mount with:
-                         sudo mkdir /sys/fs/cgroup/systemd
-                         sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
+            FAIL -- Cgroups
+                    These cgroup mounts do not exist on the host: systemd.
+                    These mounts are required to run XRd.
+                    If your distro doesn't use systemd, manually add the systemd cgroup mount with:
+                        sudo mkdir /sys/fs/cgroup/systemd
+                        sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_pids_mount_error(self, capsys):
         """Test case where systemd mount isn't present."""
@@ -1263,12 +1259,12 @@ class TestCgroups(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Cgroups
-                     These cgroup mounts do not exist on the host: pids.
-                     These mounts are required to run XRd.
+            FAIL -- Cgroups
+                    These cgroup mounts do not exist on the host: pids.
+                    These mounts are required to run XRd.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_systemd_cpu_mount_error(self, capsys):
         """Test case where systemd mount isn't present."""
@@ -1286,15 +1282,15 @@ class TestCgroups(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Cgroups
-                     These cgroup mounts do not exist on the host: systemd, cpu.
-                     These mounts are required to run XRd.
-                     If your distro doesn't use systemd, manually add the systemd cgroup mount with:
-                         sudo mkdir /sys/fs/cgroup/systemd
-                         sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
+            FAIL -- Cgroups
+                    These cgroup mounts do not exist on the host: systemd, cpu.
+                    These mounts are required to run XRd.
+                    If your distro doesn't use systemd, manually add the systemd cgroup mount with:
+                        sudo mkdir /sys/fs/cgroup/systemd
+                        sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
 
 class _TestInotifyLimitsBase(_CheckTestBase):
@@ -1308,45 +1304,45 @@ class _TestInotifyLimitsBase(_CheckTestBase):
         result, output = self.perform_check(capsys, read_effects="10000000")
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             PASS -- {self.check_name}
-                     10000000 - this is expected to be sufficient for 2500 XRd instance(s).
+            PASS -- {self.check_name}
+                    10000000 - this is expected to be sufficient for 2500 XRd instance(s).
             """
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_too_low(self, capsys):
         """Test the limit being too low."""
         result, output = self.perform_check(capsys, read_effects="3000")
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             FAIL -- {self.check_name}
-                     The kernel parameter fs.inotify.{self.inotify_param} is set to 3000 but
-                     should be at least 4000 (sufficient for a single instance) - the
-                     recommended value is 64000.
-                     This can be addressed by adding 'fs.inotify.{self.inotify_param}=64000'
-                     to /etc/sysctl.conf or in a dedicated conf file under /etc/sysctl.d/.
-                     For a temporary fix, run:
-                       sysctl -w fs.inotify.{self.inotify_param}=64000
+            FAIL -- {self.check_name}
+                    The kernel parameter fs.inotify.{self.inotify_param} is set to 3000 but
+                    should be at least 4000 (sufficient for a single instance) - the
+                    recommended value is 64000.
+                    This can be addressed by adding 'fs.inotify.{self.inotify_param}=64000'
+                    to /etc/sysctl.conf or in a dedicated conf file under /etc/sysctl.d/.
+                    For a temporary fix, run:
+                      sysctl -w fs.inotify.{self.inotify_param}=64000
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_warning_level(self, capsys):
         """Test the limit being not too low but recommended to be higher."""
         result, output = self.perform_check(capsys, read_effects="7000")
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             WARN -- {self.check_name}
-                     The kernel parameter fs.inotify.{self.inotify_param} is set to 7000 -
-                     this is expected to be sufficient for 1 XRd instance(s).
-                     The recommended value is 64000.
-                     This can be addressed by adding 'fs.inotify.{self.inotify_param}=64000'
-                     to /etc/sysctl.conf or in a dedicated conf file under /etc/sysctl.d/.
-                     For a temporary fix, run:
-                       sysctl -w fs.inotify.{self.inotify_param}=64000
+            WARN -- {self.check_name}
+                    The kernel parameter fs.inotify.{self.inotify_param} is set to 7000 -
+                    this is expected to be sufficient for 1 XRd instance(s).
+                    The recommended value is 64000.
+                    This can be addressed by adding 'fs.inotify.{self.inotify_param}=64000'
+                    to /etc/sysctl.conf or in a dedicated conf file under /etc/sysctl.d/.
+                    For a temporary fix, run:
+                      sysctl -w fs.inotify.{self.inotify_param}=64000
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_error(self, capsys):
         """Test error being raised."""
@@ -1399,7 +1395,7 @@ class TestCorePattern(_CheckTestBase):
             textwrap.dedent(output)
             == "INFO -- Core pattern (core files managed by XR)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.NEUTRAL
 
     def test_managed_by_host(self, capsys):
         """Test the managed by host case."""
@@ -1408,19 +1404,19 @@ class TestCorePattern(_CheckTestBase):
             textwrap.dedent(output)
             == "INFO -- Core pattern (core files managed by the host)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.NEUTRAL
 
     def test_error(self, capsys):
         """Test error being raised."""
         result, output = self.perform_check(capsys, read_effects=Exception)
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             INFO -- Core pattern
-                     Failed to read /proc/sys/kernel/core_pattern - unable to determine
-                     whether core files are managed by XR or the host.
+            INFO -- Core pattern
+                    Failed to read /proc/sys/kernel/core_pattern - unable to determine
+                    whether core files are managed by XR or the host.
             """
         )
-        assert result.is_success()
+        assert result is CheckState.NEUTRAL
 
 
 class TestASLR(_CheckTestBase):
@@ -1434,7 +1430,7 @@ class TestASLR(_CheckTestBase):
         """Test the success case."""
         result, output = self.perform_check(capsys, read_effects="2")
         assert textwrap.dedent(output) == "PASS -- ASLR (full randomization)\n"
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_read_error(self, capsys):
         """Test the limit being too low."""
@@ -1477,18 +1473,18 @@ class TestASLR(_CheckTestBase):
         result, output = self.perform_check(capsys, read_effects="1")
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             WARN -- ASLR
-                     The kernel paramater kernel.randomize_va_space, which controls ASLR
-                     (Address-Space Layout Randomization), is set to 1.
-                     It is recommended for this kernel parameter to be set to 2 (full
-                     randomization) for security reasons. This can be done by adding
-                     'kernel.randomize_va_space=2' to /etc/sysctl.conf or in a dedicated conf
-                     file under /etc/sysctl.d/.
-                     For a temporary fix, run:
-                       sysctl -w kernel.randomize_va_space=2
+            WARN -- ASLR
+                    The kernel paramater kernel.randomize_va_space, which controls ASLR
+                    (Address-Space Layout Randomization), is set to 1.
+                    It is recommended for this kernel parameter to be set to 2 (full
+                    randomization) for security reasons. This can be done by adding
+                    'kernel.randomize_va_space=2' to /etc/sysctl.conf or in a dedicated conf
+                    file under /etc/sysctl.d/.
+                    For a temporary fix, run:
+                      sysctl -w kernel.randomize_va_space=2
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.WARNING
 
 
 class TestLSMs(_CheckTestBase):
@@ -1505,20 +1501,20 @@ class TestLSMs(_CheckTestBase):
         """
         expected = textwrap.dedent(
             f"""\
-             INFO -- Linux Security Modules (No LSMs are enabled)
+            INFO -- Linux Security Modules (No LSMs are enabled)
             """
         )
         result, output = self.perform_check(
             capsys, read_effects=[FileNotFoundError, FileNotFoundError]
         )
         assert textwrap.dedent(output) == expected
-        assert result.is_success()
+        assert result is CheckState.NEUTRAL
 
         result, output = self.perform_check(
             capsys, read_effects=["", "SELINUX=disabled"]
         )
         assert textwrap.dedent(output) == expected
-        assert result.is_success()
+        assert result is CheckState.NEUTRAL
 
     def test_apparmor_enabled(self, capsys):
         """Test AppArmor config set to enabled."""
@@ -1528,36 +1524,36 @@ class TestLSMs(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             WARN -- Linux Security Modules
-                     AppArmor is enabled. XRd is currently unable to run with the
-                     default docker profile, but can be run with
-                     '--security-opt apparmor=unconfined' or equivalent.
-                     However, some features might not work, such as ZTP.
+            WARN -- Linux Security Modules
+                    AppArmor is enabled. XRd is currently unable to run with the
+                    default docker profile, but can be run with
+                    '--security-opt apparmor=unconfined' or equivalent.
+                    However, some features might not work, such as ZTP.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.WARNING
 
     def test_selinux_enabled(self, capsys):
         """Test SELinux config set to enabled."""
         expected = textwrap.dedent(
             f"""\
-             INFO -- Linux Security Modules
-                     SELinux is enabled. XRd is currently unable to run with the
-                     default policy, but can be run with
-                     '--security-opt label=disable' or equivalent.
+            INFO -- Linux Security Modules
+                    SELinux is enabled. XRd is currently unable to run with the
+                    default policy, but can be run with
+                    '--security-opt label=disable' or equivalent.
             """
         )
         result, output = self.perform_check(
             capsys, read_effects=[FileNotFoundError, "SELINUX=enforcing"]
         )
         assert textwrap.dedent(output) == expected
-        assert result.is_success()
+        assert result is CheckState.NEUTRAL
 
         result, output = self.perform_check(
             capsys, read_effects=["", "SELINUX=enforcing"]
         )
         assert textwrap.dedent(output) == expected
-        assert result.is_success()
+        assert result is CheckState.NEUTRAL
 
     def test_both_enabled(self, capsys):
         """Test the case where both AppArmor and SELinux are enabled."""
@@ -1567,17 +1563,17 @@ class TestLSMs(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             WARN -- Linux Security Modules
-                     AppArmor is enabled. XRd is currently unable to run with the
-                     default docker profile, but can be run with
-                     '--security-opt apparmor=unconfined' or equivalent.
-                     However, some features might not work, such as ZTP.
-                     SELinux is enabled. XRd is currently unable to run with the
-                     default policy, but can be run with
-                     '--security-opt label=disable' or equivalent.
+            WARN -- Linux Security Modules
+                    AppArmor is enabled. XRd is currently unable to run with the
+                    default docker profile, but can be run with
+                    '--security-opt apparmor=unconfined' or equivalent.
+                    However, some features might not work, such as ZTP.
+                    SELinux is enabled. XRd is currently unable to run with the
+                    default policy, but can be run with
+                    '--security-opt label=disable' or equivalent.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.WARNING
 
 
 class TestRealtimeGroupSched(_CheckTestBase):
@@ -1597,7 +1593,7 @@ class TestRealtimeGroupSched(_CheckTestBase):
             textwrap.dedent(output)
             == "PASS -- Real-time Group Scheduling (disabled in kernel config)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_v1_disabled_at_runtime(self, capsys):
         """Test the v1 case where disabled at runtime"""
@@ -1609,7 +1605,7 @@ class TestRealtimeGroupSched(_CheckTestBase):
             textwrap.dedent(output)
             == "PASS -- Real-time Group Scheduling (disabled at runtime)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_v1_read_error(self, capsys):
         """Test the limit being too low."""
@@ -1641,19 +1637,19 @@ class TestRealtimeGroupSched(_CheckTestBase):
             result, output = self.perform_check(capsys, read_effects="950000")
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Real-time Group Scheduling
-                     The kernel parameter kernel.sched_rt_runtime_us is set to 950000
-                     but must be disabled by setting it to '-1'.
-                     Running with real-time group scheduling enabled is not supported.
-                     If real-time group scheduling (RT_GROUP_SCHED) is configured in the kernel,
-                     it is required that this feature is disabled at runtime by adding
-                     'kernel.sched_rt_runtime_us=-1' to /etc/sysctl.conf or in a dedicated conf
-                     file under /etc/sysctl.d/.
-                     For a temporary fix, run:
-                       sysctl -w kernel.sched_rt_runtime_us=-1
+            FAIL -- Real-time Group Scheduling
+                    The kernel parameter kernel.sched_rt_runtime_us is set to 950000
+                    but must be disabled by setting it to '-1'.
+                    Running with real-time group scheduling enabled is not supported.
+                    If real-time group scheduling (RT_GROUP_SCHED) is configured in the kernel,
+                    it is required that this feature is disabled at runtime by adding
+                    'kernel.sched_rt_runtime_us=-1' to /etc/sysctl.conf or in a dedicated conf
+                    file under /etc/sysctl.d/.
+                    For a temporary fix, run:
+                      sysctl -w kernel.sched_rt_runtime_us=-1
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_v2_disabled_in_kernel_config(self, capsys):
         """Test the v2 case where disabled in kernel config"""
@@ -1665,7 +1661,7 @@ class TestRealtimeGroupSched(_CheckTestBase):
             textwrap.dedent(output)
             == "PASS -- Real-time Group Scheduling (disabled in kernel config)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_v2_disabled_at_runtime(self, capsys):
         """Test the v2 case where disabled at runtime"""
@@ -1677,7 +1673,7 @@ class TestRealtimeGroupSched(_CheckTestBase):
             textwrap.dedent(output)
             == "PASS -- Real-time Group Scheduling (disabled at runtime)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_v2_failure_enabled_at_runtime(self, capsys):
         """Test the check fails in the v2 case where enabled at runtime"""
@@ -1687,19 +1683,19 @@ class TestRealtimeGroupSched(_CheckTestBase):
             result, output = self.perform_check(capsys, read_effects="950000")
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Real-time Group Scheduling
-                     The kernel parameter kernel.sched_rt_runtime_us is set to 950000
-                     but must be disabled by setting it to '-1'.
-                     Running with real-time group scheduling enabled is not supported.
-                     If real-time group scheduling (RT_GROUP_SCHED) is configured in the kernel,
-                     it is required that this feature is disabled at runtime by adding
-                     'kernel.sched_rt_runtime_us=-1' to /etc/sysctl.conf or in a dedicated conf
-                     file under /etc/sysctl.d/.
-                     For a temporary fix, run:
-                       sysctl -w kernel.sched_rt_runtime_us=-1
+            FAIL -- Real-time Group Scheduling
+                    The kernel parameter kernel.sched_rt_runtime_us is set to 950000
+                    but must be disabled by setting it to '-1'.
+                    Running with real-time group scheduling enabled is not supported.
+                    If real-time group scheduling (RT_GROUP_SCHED) is configured in the kernel,
+                    it is required that this feature is disabled at runtime by adding
+                    'kernel.sched_rt_runtime_us=-1' to /etc/sysctl.conf or in a dedicated conf
+                    file under /etc/sysctl.d/.
+                    For a temporary fix, run:
+                      sysctl -w kernel.sched_rt_runtime_us=-1
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
 
 class TestSocketParameters(_CheckTestBase):
@@ -1733,7 +1729,7 @@ class TestSocketParameters(_CheckTestBase):
             textwrap.dedent(output)
             == "PASS -- Socket kernel parameters (valid settings)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_higher_values(self, capsys):
         """Test when values are higher, the check passes."""
@@ -1750,7 +1746,7 @@ class TestSocketParameters(_CheckTestBase):
             textwrap.dedent(output)
             == "PASS -- Socket kernel parameters (valid settings)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_lower_values(self, capsys):
         """Test when values are lower, the check warns."""
@@ -1765,37 +1761,37 @@ class TestSocketParameters(_CheckTestBase):
         result, output = self.perform_check(capsys, read_effects=lower_values)
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             WARN -- Socket kernel parameters
-                     The kernel socket parameters are insufficient for running XRd in a
-                     production deployment. They may be used in a lab deployment, but must
-                     be increased to the required minimums for production deployment.
-                     Lower values may result in XR IPC loss and unpredictable behavior,
-                     particularly at higher scale.
+            WARN -- Socket kernel parameters
+                    The kernel socket parameters are insufficient for running XRd in a
+                    production deployment. They may be used in a lab deployment, but must
+                    be increased to the required minimums for production deployment.
+                    Lower values may result in XR IPC loss and unpredictable behavior,
+                    particularly at higher scale.
 
-                     The required minimum settings are:
-                         net.core.netdev_max_backlog=300000
-                         net.core.optmem_max=67108864
-                         net.core.rmem_default=67108864
-                         net.core.rmem_max=67108864
-                         net.core.wmem_default=67108864
-                         net.core.wmem_max=67108864
+                    The required minimum settings are:
+                        net.core.netdev_max_backlog=300000
+                        net.core.optmem_max=67108864
+                        net.core.rmem_default=67108864
+                        net.core.rmem_max=67108864
+                        net.core.wmem_default=67108864
+                        net.core.wmem_max=67108864
 
-                     The current host settings are:
-                         net.core.netdev_max_backlog=1000
-                         net.core.optmem_max=20480
-                         net.core.rmem_default=212992
-                         net.core.rmem_max=212992
-                         net.core.wmem_default=212992
-                         net.core.wmem_max=212992
+                    The current host settings are:
+                        net.core.netdev_max_backlog=1000
+                        net.core.optmem_max=20480
+                        net.core.rmem_default=212992
+                        net.core.rmem_max=212992
+                        net.core.wmem_default=212992
+                        net.core.wmem_max=212992
 
-                     Values can be changed by adding e.g.
-                     'net.core.rmem_default=67108864' to /etc/sysctl.conf or
-                     in a dedicated conf file under /etc/sysctl.d/.
-                     Or for a temporary fix, running e.g.:
-                       sysctl -w net.core.rmem_default=67108864
+                    Values can be changed by adding e.g.
+                    'net.core.rmem_default=67108864' to /etc/sysctl.conf or
+                    in a dedicated conf file under /etc/sysctl.d/.
+                    Or for a temporary fix, running e.g.:
+                      sysctl -w net.core.rmem_default=67108864
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.WARNING
 
     def test_read_failure(self, capsys):
         """Test read failure on socket parameter"""
@@ -1831,7 +1827,7 @@ class TestUDPParameters(_CheckTestBase):
             textwrap.dedent(output)
             == "PASS -- UDP kernel parameters (valid settings)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_higher_values(self, capsys):
         """Test when values are higher, the check passes."""
@@ -1842,7 +1838,7 @@ class TestUDPParameters(_CheckTestBase):
             textwrap.dedent(output)
             == "PASS -- UDP kernel parameters (valid settings)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_lower_values(self, capsys):
         """Test when values are lower, the check warns."""
@@ -1852,75 +1848,75 @@ class TestUDPParameters(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             WARN -- UDP kernel parameters
-                     The kernel UDP parameters are insufficient for running XRd in a
-                     production deployment. They may be used in a lab deployment, but must
-                     be increased to the required minimums for production deployment.
-                     Lower values may result in XR IPC loss and unpredictable behavior,
-                     particularly at higher scale.
+            WARN -- UDP kernel parameters
+                    The kernel UDP parameters are insufficient for running XRd in a
+                    production deployment. They may be used in a lab deployment, but must
+                    be increased to the required minimums for production deployment.
+                    Lower values may result in XR IPC loss and unpredictable behavior,
+                    particularly at higher scale.
 
-                     The required minimum settings are:
-                         net.ipv4.udp_mem=1124736 10000000 67108864
-                     The current host settings are:
-                         net.ipv4.udp_mem=767055 1022741 1534110
-                     Values can be changed by adding
-                     'net.ipv4.udp_mem=1124736 10000000 67108864' to /etc/sysctl.conf or
-                     in a dedicated conf file under /etc/sysctl.d/.
-                     Or for a temporary fix, running:
-                       sysctl -w net.ipv4.udp_mem='1124736 10000000 67108864'
+                    The required minimum settings are:
+                        net.ipv4.udp_mem=1124736 10000000 67108864
+                    The current host settings are:
+                        net.ipv4.udp_mem=767055 1022741 1534110
+                    Values can be changed by adding
+                    'net.ipv4.udp_mem=1124736 10000000 67108864' to /etc/sysctl.conf or
+                    in a dedicated conf file under /etc/sysctl.d/.
+                    Or for a temporary fix, running:
+                      sysctl -w net.ipv4.udp_mem='1124736 10000000 67108864'
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.WARNING
 
         result, output = self.perform_check(
             capsys, read_effects="1124736 1022741 1534110"
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             WARN -- UDP kernel parameters
-                     The kernel UDP parameters are insufficient for running XRd in a
-                     production deployment. They may be used in a lab deployment, but must
-                     be increased to the required minimums for production deployment.
-                     Lower values may result in XR IPC loss and unpredictable behavior,
-                     particularly at higher scale.
+            WARN -- UDP kernel parameters
+                    The kernel UDP parameters are insufficient for running XRd in a
+                    production deployment. They may be used in a lab deployment, but must
+                    be increased to the required minimums for production deployment.
+                    Lower values may result in XR IPC loss and unpredictable behavior,
+                    particularly at higher scale.
 
-                     The required minimum settings are:
-                         net.ipv4.udp_mem=1124736 10000000 67108864
-                     The current host settings are:
-                         net.ipv4.udp_mem=1124736 1022741 1534110
-                     Values can be changed by adding
-                     'net.ipv4.udp_mem=1124736 10000000 67108864' to /etc/sysctl.conf or
-                     in a dedicated conf file under /etc/sysctl.d/.
-                     Or for a temporary fix, running:
-                       sysctl -w net.ipv4.udp_mem='1124736 10000000 67108864'
+                    The required minimum settings are:
+                        net.ipv4.udp_mem=1124736 10000000 67108864
+                    The current host settings are:
+                        net.ipv4.udp_mem=1124736 1022741 1534110
+                    Values can be changed by adding
+                    'net.ipv4.udp_mem=1124736 10000000 67108864' to /etc/sysctl.conf or
+                    in a dedicated conf file under /etc/sysctl.d/.
+                    Or for a temporary fix, running:
+                      sysctl -w net.ipv4.udp_mem='1124736 10000000 67108864'
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.WARNING
 
         result, output = self.perform_check(
             capsys, read_effects="1124736 10000000 1534110"
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             WARN -- UDP kernel parameters
-                     The kernel UDP parameters are insufficient for running XRd in a
-                     production deployment. They may be used in a lab deployment, but must
-                     be increased to the required minimums for production deployment.
-                     Lower values may result in XR IPC loss and unpredictable behavior,
-                     particularly at higher scale.
+            WARN -- UDP kernel parameters
+                    The kernel UDP parameters are insufficient for running XRd in a
+                    production deployment. They may be used in a lab deployment, but must
+                    be increased to the required minimums for production deployment.
+                    Lower values may result in XR IPC loss and unpredictable behavior,
+                    particularly at higher scale.
 
-                     The required minimum settings are:
-                         net.ipv4.udp_mem=1124736 10000000 67108864
-                     The current host settings are:
-                         net.ipv4.udp_mem=1124736 10000000 1534110
-                     Values can be changed by adding
-                     'net.ipv4.udp_mem=1124736 10000000 67108864' to /etc/sysctl.conf or
-                     in a dedicated conf file under /etc/sysctl.d/.
-                     Or for a temporary fix, running:
-                       sysctl -w net.ipv4.udp_mem='1124736 10000000 67108864'
+                    The required minimum settings are:
+                        net.ipv4.udp_mem=1124736 10000000 67108864
+                    The current host settings are:
+                        net.ipv4.udp_mem=1124736 10000000 1534110
+                    Values can be changed by adding
+                    'net.ipv4.udp_mem=1124736 10000000 67108864' to /etc/sysctl.conf or
+                    in a dedicated conf file under /etc/sysctl.d/.
+                    Or for a temporary fix, running:
+                      sysctl -w net.ipv4.udp_mem='1124736 10000000 67108864'
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.WARNING
 
     def test_read_failure(self, capsys):
         """Test read failure on socket parameter"""
@@ -1956,14 +1952,14 @@ Swap:   31798079488  2008911872 29789167616
         result, output = self.perform_check(capsys, cmd_effects=cmd_output)
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             PASS -- RAM
-                     Available RAM is 2.6 GiB.
-                     This is estimated to be sufficient for 1 XRd instance(s), although memory
-                     usage depends on the running configuration.
-                     Note that any swap that may be available is not included.
+            PASS -- RAM
+                    Available RAM is 2.6 GiB.
+                    This is estimated to be sufficient for 1 XRd instance(s), although memory
+                    usage depends on the running configuration.
+                    Note that any swap that may be available is not included.
             """
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_subproc_error(self, capsys):
         """Test a subprocess error being raised."""
@@ -2005,13 +2001,13 @@ Swap:   31798079488  2008911872 29789167616
         result, output = self.perform_check(capsys, cmd_effects=cmd_output)
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             WARN -- RAM
-                     The available RAM on the host (1.6 GiB) may be insufficient to run XRd.
-                     Each XRd instance is expected to require 2 GiB of RAM for normal use.
-                     Note that this does not include any swap that may be available.
+            WARN -- RAM
+                    The available RAM on the host (1.6 GiB) may be insufficient to run XRd.
+                    Each XRd instance is expected to require 2 GiB of RAM for normal use.
+                    Note that this does not include any swap that may be available.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.WARNING
 
     def test_unexpected_error(self, capsys):
         """Test unexpected error being raised."""
@@ -2043,7 +2039,7 @@ class TestCPUExtensions(_CheckTestBase):
             textwrap.dedent(output)
             == f"PASS -- CPU extensions (sse4_1, sse4_2, ssse3)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_parse_error(self, capsys):
         """Test the case where the CPU extensions cannot be parsed."""
@@ -2063,12 +2059,12 @@ class TestCPUExtensions(_CheckTestBase):
         result, output = self.perform_check(capsys, cmd_effects="Flags: ssse3")
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             FAIL -- CPU extensions
-                     Missing CPU extension(s): sse4_1, sse4_2
-                     Please install the missing extension(s).
+            FAIL -- CPU extensions
+                    Missing CPU extension(s): sse4_1, sse4_2
+                    Please install the missing extension(s).
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_subproc_error(self, capsys):
         """Test a subprocess error being raised."""
@@ -2120,10 +2116,10 @@ class TestHugepages(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             PASS -- Hugepages (3 x 1GiB)
+            PASS -- Hugepages (3 x 1GiB)
             """
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_2_MB_supported(self, capsys):
         """Test the case where only 2 MiB hugepages are supported and in use."""
@@ -2139,12 +2135,12 @@ class TestHugepages(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             WARN -- Hugepages
-                     2MiB hugepages are available, but only 1GiB hugepages are
-                     supported for XRd deployment use cases.
+            WARN -- Hugepages
+                    2MiB hugepages are available, but only 1GiB hugepages are
+                    supported for XRd deployment use cases.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.WARNING
 
     def test_unaccepted_size(self, capsys):
         """Test the case where the hugepages size is not accepted."""
@@ -2160,11 +2156,11 @@ class TestHugepages(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Hugepages
-                     3MiB hugepages are available, but XRd requires 1GiB hugepages.
+            FAIL -- Hugepages
+                    3MiB hugepages are available, but XRd requires 1GiB hugepages.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_insufficient_memory_1_GB(self, capsys):
         """
@@ -2183,12 +2179,12 @@ class TestHugepages(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Hugepages
-                     Only 2.0GiB of hugepage memory available, but XRd
-                     requires at least 3GiB.
+            FAIL -- Hugepages
+                    Only 2.0GiB of hugepage memory available, but XRd
+                    requires at least 3GiB.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_insufficient_memory_2_MB(self, capsys):
         """
@@ -2207,14 +2203,14 @@ class TestHugepages(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Hugepages
-                     2MiB hugepages are available, but only 1GiB hugepages are
-                     supported for XRd deployment use cases.
-                     Only 1.0GiB of hugepage memory available, but XRd
-                     requires at least 3GiB.
+            FAIL -- Hugepages
+                    2MiB hugepages are available, but only 1GiB hugepages are
+                    supported for XRd deployment use cases.
+                    Only 1.0GiB of hugepage memory available, but XRd
+                    requires at least 3GiB.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_hugepages_disabled(self, capsys):
         """Test the case where hugepages are not enabled."""
@@ -2230,13 +2226,13 @@ class TestHugepages(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Hugepages
-                     Hugepages are not enabled. These are required for XRd to function correctly.
-                     To enable hugepages, see the instructions at:
-                     https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt.
+            FAIL -- Hugepages
+                    Hugepages are not enabled. These are required for XRd to function correctly.
+                    To enable hugepages, see the instructions at:
+                    https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_mem_oserror(self, capsys):
         """Test an OS error being raised when trying to read from /proc/meminfo."""
@@ -2303,11 +2299,11 @@ class TestGDPKernelDriver(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             PASS -- Interface kernel driver
-                     Loaded PCI drivers: vfio-pci, igb_uio
+            PASS -- Interface kernel driver
+                    Loaded PCI drivers: vfio-pci, igb_uio
             """
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_both_builtin(self, capsys):
         """Test the case where both PCI drivers are builtin."""
@@ -2325,11 +2321,11 @@ class TestGDPKernelDriver(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             PASS -- Interface kernel driver
-                     Loaded PCI drivers: vfio-pci, igb_uio
+            PASS -- Interface kernel driver
+                    Loaded PCI drivers: vfio-pci, igb_uio
             """
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_both_installed(self, capsys):
         """Test the case where vfio-pci is installed but not loaded."""
@@ -2347,13 +2343,13 @@ class TestGDPKernelDriver(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             FAIL -- Interface kernel driver
-                     None of the expected PCI drivers are loaded.
-                     The following PCI drivers are installed but not loaded: vfio-pci, igb_uio.
-                     Run 'modprobe <pci driver>' to load a driver.
+            FAIL -- Interface kernel driver
+                    None of the expected PCI drivers are loaded.
+                    The following PCI drivers are installed but not loaded: vfio-pci, igb_uio.
+                    Run 'modprobe <pci driver>' to load a driver.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_both_missing(self, capsys):
         """Test the case where vfio-pci is not loaded."""
@@ -2370,13 +2366,13 @@ class TestGDPKernelDriver(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             FAIL -- Interface kernel driver
-                     No PCI drivers are loaded or installed.
-                     Must have either the vfio-pci or igb_uio kernel module loaded.
-                     It may be possible to install using your distro's package manager.
+            FAIL -- Interface kernel driver
+                    No PCI drivers are loaded or installed.
+                    Must have either the vfio-pci or igb_uio kernel module loaded.
+                    It may be possible to install using your distro's package manager.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_loaded_and_installed(self, capsys):
         """Test where vfio-pci is loaded and igb_uio is installed but not loaded."""
@@ -2393,13 +2389,13 @@ class TestGDPKernelDriver(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             INFO -- Interface kernel driver
-                     The following PCI drivers are installed but not loaded: igb_uio.
-                     Loaded PCI drivers: vfio-pci.
-                     Run 'modprobe <pci driver>' to load a driver.
+            INFO -- Interface kernel driver
+                    The following PCI drivers are installed but not loaded: igb_uio.
+                    Loaded PCI drivers: vfio-pci.
+                    Run 'modprobe <pci driver>' to load a driver.
             """
         )
-        assert result.is_success()
+        assert result is CheckState.NEUTRAL
 
     def test_installed_and_builtin(self, capsys):
         """Test where vfio-pci is installed but not loaded and igb_uio is builtin."""
@@ -2416,13 +2412,13 @@ class TestGDPKernelDriver(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             INFO -- Interface kernel driver
-                     The following PCI drivers are installed but not loaded: vfio-pci.
-                     Loaded PCI drivers: igb_uio.
-                     Run 'modprobe <pci driver>' to load a driver.
+            INFO -- Interface kernel driver
+                    The following PCI drivers are installed but not loaded: vfio-pci.
+                    Loaded PCI drivers: igb_uio.
+                    Run 'modprobe <pci driver>' to load a driver.
             """
         )
-        assert result.is_success()
+        assert result is CheckState.NEUTRAL
 
     def test_missing_and_installed(self, capsys):
         """Test where vfio-pci is missing and igb_uio is installed."""
@@ -2439,13 +2435,13 @@ class TestGDPKernelDriver(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             FAIL -- Interface kernel driver
-                     None of the expected PCI drivers are loaded.
-                     The following PCI drivers are installed but not loaded: igb_uio.
-                     Run 'modprobe <pci driver>' to load a driver.
+            FAIL -- Interface kernel driver
+                    None of the expected PCI drivers are loaded.
+                    The following PCI drivers are installed but not loaded: igb_uio.
+                    Run 'modprobe <pci driver>' to load a driver.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_unexpected_error(self, capsys):
         """Test unexpected error being raised."""
@@ -2511,13 +2507,13 @@ pci@0000:00:01.0  device2     network    Ethernet interface
             )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             PASS -- IOMMU
-                     IOMMU enabled for vfio-pci with the following PCI device(s):
-                     device1 (0000:00:00.0), device2 (0000:00:01.0), device3 (0000:00:02.0),
-                     device4 (0000:00:1f.2)
+            PASS -- IOMMU
+                    IOMMU enabled for vfio-pci with the following PCI device(s):
+                    device1 (0000:00:00.0), device2 (0000:00:01.0), device3 (0000:00:02.0),
+                    device4 (0000:00:1f.2)
             """
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_no_iommu_devices(self, capsys):
         """Test the case where no devices are found."""
@@ -2542,11 +2538,11 @@ pci@0000:00:1f.2  docker0     network    Ethernet interface
             )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             WARN -- IOMMU
-                     IOMMU enabled for vfio-pci, but no network PCI devices found.
+            WARN -- IOMMU
+                    IOMMU enabled for vfio-pci, but no network PCI devices found.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.WARNING
 
     def test_lshw_error(self, capsys):
         """Test the case where an error is hit when searching for network devices."""
@@ -2607,10 +2603,10 @@ Bus info          Device      Class      Description
             )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             WARN -- IOMMU (no PCI network devices found)
+            WARN -- IOMMU (no PCI network devices found)
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.WARNING
 
     def test_iommu_directory_check_error(self, capsys):
         """Test the case where the IOMMU check throws an error."""
@@ -2649,12 +2645,12 @@ Bus info          Device      Class      Description
             )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             WARN -- IOMMU
-                     The kernel module vfio-pci cannot be used, as IOMMU is not enabled.
-                     IOMMU is recommended for security when using the vfio-pci kernel driver.
+            WARN -- IOMMU
+                    The kernel module vfio-pci cannot be used, as IOMMU is not enabled.
+                    IOMMU is recommended for security when using the vfio-pci kernel driver.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.WARNING
 
     def test_no_iommu_mode(self, capsys):
         """Test the case where vfio-pci is set up in no-IOMMU mode."""
@@ -2670,11 +2666,11 @@ Bus info          Device      Class      Description
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             WARN -- IOMMU
-                     vfio-pci is set up in no-IOMMU mode, but IOMMU is recommended for security.
+            WARN -- IOMMU
+                    vfio-pci is set up in no-IOMMU mode, but IOMMU is recommended for security.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.WARNING
 
     def test_no_iommu_unconfigurable(self, capsys):
         """
@@ -2714,13 +2710,13 @@ pci@0000:00:01.0  device2     network    Ethernet interface
             )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             PASS -- IOMMU
-                     IOMMU enabled for vfio-pci with the following PCI device(s):
-                     device1 (0000:00:00.0), device2 (0000:00:01.0), device3 (0000:00:02.0),
-                     device4 (0000:00:1f.2)
+            PASS -- IOMMU
+                    IOMMU enabled for vfio-pci with the following PCI device(s):
+                    device1 (0000:00:00.0), device2 (0000:00:01.0), device3 (0000:00:02.0),
+                    device4 (0000:00:1f.2)
             """
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_unexpected_error(self, capsys):
         """Test unexpected error being raised."""
@@ -2747,11 +2743,11 @@ pci@0000:00:01.0  device2     network    Ethernet interface
         result, output = self.perform_check(capsys, failed_deps=self.deps)
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             SKIP -- IOMMU
-                     Skipped due to failed checks: Interface kernel driver
+            SKIP -- IOMMU
+                    Skipped due to failed checks: Interface kernel driver
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.SKIPPED
 
     def test_vfio_pci_not_enabled(self, capsys):
         """Test for when vfio-pci is not enabled."""
@@ -2764,10 +2760,10 @@ pci@0000:00:01.0  device2     network    Ethernet interface
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             INFO -- IOMMU (vfio-pci driver unavailable)
+            INFO -- IOMMU (vfio-pci driver unavailable)
             """
         )
-        assert result.is_success()
+        assert result is CheckState.NEUTRAL
 
     def test_warn_igb_uio_enabled(self, capsys):
         """
@@ -2779,11 +2775,11 @@ pci@0000:00:01.0  device2     network    Ethernet interface
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             INFO -- IOMMU
-                     vfio-pci is set up in no-IOMMU mode, but IOMMU is recommended for security.
+            INFO -- IOMMU
+                    vfio-pci is set up in no-IOMMU mode, but IOMMU is recommended for security.
             """
         )
-        assert result.is_success()
+        assert result is CheckState.NEUTRAL
 
 
 class TestSharedMemPageMaxSize(_CheckTestBase):
@@ -2800,7 +2796,7 @@ class TestSharedMemPageMaxSize(_CheckTestBase):
             textwrap.dedent(output)
             == "PASS -- Shared memory pages max size (2.0 GiB)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_oserror(self, capsys):
         """Test the OS error case."""
@@ -2820,12 +2816,12 @@ class TestSharedMemPageMaxSize(_CheckTestBase):
         result, output = self.perform_check(capsys, read_effects="1073741824")
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Shared memory pages max size
-                     The maximum size of shared memory pages is 1.0 GiB,
-                     but at least 2 GiB are required.
+            FAIL -- Shared memory pages max size
+                    The maximum size of shared memory pages is 1.0 GiB,
+                    but at least 2 GiB are required.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_exception(self, capsys):
         """Test the Exception case."""
@@ -2877,7 +2873,7 @@ class TestDockerClient(_CheckTestBase):
             textwrap.dedent(output)
             == "PASS -- Docker client (version 18.0.4)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_subproc_error(self, capsys):
         """Test a subprocess error being raised."""
@@ -2886,14 +2882,14 @@ class TestDockerClient(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Docker client
-                     Docker client not correctly installed on the host (checked with
-                     'docker --version').
-                     See installation instructions at https://docs.docker.com/engine/install/.
-                     At least version 18.0 is required for XRd.
+            FAIL -- Docker client
+                    Docker client not correctly installed on the host (checked with
+                    'docker --version').
+                    See installation instructions at https://docs.docker.com/engine/install/.
+                    At least version 18.0 is required for XRd.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_no_version_match(self, capsys):
         """Test failure to match the version in the output."""
@@ -2916,12 +2912,12 @@ class TestDockerClient(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Docker client
-                     Docker version must be at least 18.0, current client version is 17.11.
-                     See installation instructions at https://docs.docker.com/engine/install/.
+            FAIL -- Docker client
+                    Docker version must be at least 18.0, current client version is 17.11.
+                    See installation instructions at https://docs.docker.com/engine/install/.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_unexpected_error(self, capsys):
         """Test unexpected error being raised."""
@@ -2952,7 +2948,7 @@ class TestDockerDaemon(_CheckTestBase):
             textwrap.dedent(output)
             == "PASS -- Docker daemon (running, version 18.0.4)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_subproc_error(self, capsys):
         """Test a subprocess error being raised."""
@@ -2961,14 +2957,14 @@ class TestDockerDaemon(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Docker daemon
-                     Unable to connect to the Docker daemon (checked with
-                     "docker version -f '{{json .Server.Version}}'").
-                     This could be because it isn't running, or due to insufficient permissions.
-                     See installation instructions at https://docs.docker.com/engine/install/.
+            FAIL -- Docker daemon
+                    Unable to connect to the Docker daemon (checked with
+                    "docker version -f '{{json .Server.Version}}'").
+                    This could be because it isn't running, or due to insufficient permissions.
+                    See installation instructions at https://docs.docker.com/engine/install/.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_no_version_match(self, capsys):
         """Test failure to match the version in the output."""
@@ -2990,12 +2986,12 @@ class TestDockerDaemon(_CheckTestBase):
         result, output = self.perform_check(capsys, cmd_effects='"17.11"')
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Docker daemon
-                     Docker version must be at least 18.0, current server version is 17.11.
-                     See installation instructions at https://docs.docker.com/engine/install/.
+            FAIL -- Docker daemon
+                    Docker version must be at least 18.0, current server version is 17.11.
+                    See installation instructions at https://docs.docker.com/engine/install/.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_unexpected_error(self, capsys):
         """Test unexpected error being raised."""
@@ -3015,11 +3011,11 @@ class TestDockerDaemon(_CheckTestBase):
         result, output = self.perform_check(capsys, failed_deps=self.deps)
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             SKIP -- Docker daemon
-                     Skipped due to failed checks: Docker client
+            SKIP -- Docker daemon
+                    Skipped due to failed checks: Docker client
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.SKIPPED
 
 
 class TestDtypeSupport(_CheckTestBase):
@@ -3036,7 +3032,7 @@ class TestDtypeSupport(_CheckTestBase):
             capsys, cmd_effects="Supports d_type: true"
         )
         assert textwrap.dedent(output) == "PASS -- Docker supports d_type\n"
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_subproc_error(self, capsys):
         """Test a subprocess error being raised."""
@@ -3060,13 +3056,13 @@ class TestDtypeSupport(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- Docker supports d_type
-                     Docker is using a backing filesystem that does not support d_type
-                     (directory entry type).
-                     This is required for XRd to avoid issues with creating and deleting files.
+            FAIL -- Docker supports d_type
+                    Docker is using a backing filesystem that does not support d_type
+                    (directory entry type).
+                    This is required for XRd to avoid issues with creating and deleting files.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_unexpected_error(self, capsys):
         """Test unexpected error being raised."""
@@ -3086,11 +3082,11 @@ class TestDtypeSupport(_CheckTestBase):
         result, output = self.perform_check(capsys, failed_deps=self.deps)
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             SKIP -- Docker supports d_type
-                     Skipped due to failed checks: Docker daemon
+            SKIP -- Docker supports d_type
+                    Skipped due to failed checks: Docker daemon
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.SKIPPED
 
 
 # -------------------------------------
@@ -3114,7 +3110,7 @@ class TestDockerCompose(_CheckTestBase):
             textwrap.dedent(output)
             == "PASS -- docker-compose (version 1.18.0)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_subproc_error(self, capsys):
         """Test a subprocess error being raised."""
@@ -3123,13 +3119,13 @@ class TestDockerCompose(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- docker-compose
-                     Docker Compose not found (checked with 'docker-compose --version').
-                     Launching XRd topologies with xr-compose requires docker-compose.
-                     See installation instructions at https://docs.docker.com/compose/install/.
+            FAIL -- docker-compose
+                    Docker Compose not found (checked with 'docker-compose --version').
+                    Launching XRd topologies with xr-compose requires docker-compose.
+                    See installation instructions at https://docs.docker.com/compose/install/.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_no_version_match(self, capsys):
         """Test failure to match the version in the output."""
@@ -3151,12 +3147,12 @@ class TestDockerCompose(_CheckTestBase):
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-             FAIL -- docker-compose
-                     Docker Compose version must be at least 1.18, current version is 1.17.10.
-                     See installation instructions at https://docs.docker.com/compose/install/.
+            FAIL -- docker-compose
+                    Docker Compose version must be at least 1.18, current version is 1.17.10.
+                    See installation instructions at https://docs.docker.com/compose/install/.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_unexpected_error(self, capsys):
         """Test unexpected error being raised."""
@@ -3183,7 +3179,7 @@ class TestPyYAML(_CheckTestBase):
         with mock.patch("builtins.__import__"):
             result, output = self.perform_check(capsys)
         assert textwrap.dedent(output) == f"PASS -- PyYAML (installed)\n"
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_unavailable(self, capsys):
         """Test yaml not being available."""
@@ -3191,12 +3187,12 @@ class TestPyYAML(_CheckTestBase):
             result, output = self.perform_check(capsys)
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             FAIL -- PyYAML
-                     PyYAML Python package not installed - required for running xr-compose.
-                     Install with 'python3 -m pip install pyyaml'.
+            FAIL -- PyYAML
+                    PyYAML Python package not installed - required for running xr-compose.
+                    Install with 'python3 -m pip install pyyaml'.
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_unexpected_error(self, capsys):
         """Test unexpected error being raised."""
@@ -3229,28 +3225,28 @@ class TestBridgeIptables(_CheckTestBase):
         assert (
             textwrap.dedent(output) == "PASS -- Bridge iptables (disabled)\n"
         )
-        assert result.is_success()
+        assert result is CheckState.SUCCESS
 
     def test_not_disabled(self, capsys):
         """Test bridge iptables not being disabled."""
         result, output = self.perform_check(capsys, read_effects=["0", "1"])
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-             FAIL -- Bridge iptables
-                     For xr-compose to be able to use Docker bridges, bridge IP tables must
-                     be disabled. Note that there may be security considerations associated
-                     with doing so.
-                     Bridge IP tables can be disabled by setting the kernel parameters
-                     net.bridge.bridge-nf-call-iptables and net.bridge.bridge-nf-call-ip6tables
-                     to 0. These can be modified by adding 'net.bridge.bridge-nf-call-iptables=0'
-                     and 'net.bridge.bridge-nf-call-ip6tables=0' to /etc/sysctl.conf or in a
-                     dedicated conf file under /etc/sysctl.d/.
-                     For a temporary fix, run:
-                       sysctl -w net.bridge.bridge-nf-call-iptables=0
-                       sysctl -w net.bridge.bridge-nf-call-ip6tables=0
+            FAIL -- Bridge iptables
+                    For xr-compose to be able to use Docker bridges, bridge IP tables must
+                    be disabled. Note that there may be security considerations associated
+                    with doing so.
+                    Bridge IP tables can be disabled by setting the kernel parameters
+                    net.bridge.bridge-nf-call-iptables and net.bridge.bridge-nf-call-ip6tables
+                    to 0. These can be modified by adding 'net.bridge.bridge-nf-call-iptables=0'
+                    and 'net.bridge.bridge-nf-call-ip6tables=0' to /etc/sysctl.conf or in a
+                    dedicated conf file under /etc/sysctl.d/.
+                    For a temporary fix, run:
+                      sysctl -w net.bridge.bridge-nf-call-iptables=0
+                      sysctl -w net.bridge.bridge-nf-call-ip6tables=0
             """
         )
-        assert result.is_failure()
+        assert result is CheckState.FAILED
 
     def test_error(self, capsys):
         """Test error being raised."""

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -89,7 +89,7 @@ def perform_check(
     :param failed_deps:
         Any dependencies to treat as failed.
     :return:
-        The result of the check, whether the check errored, and the output from the check.
+        The overall result of the check, and the output from the check.
     """
     check = [c for c in CHECKS_BY_GROUP[group] if c.name == name][0]
     checks = []

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -31,7 +31,7 @@ from .utils import REPO_ROOT_DIR
 
 HOST_CHECK_SCRIPT = REPO_ROOT_DIR / "scripts" / "host-check"
 host_check = utils.import_path(HOST_CHECK_SCRIPT)
-
+OverallCheckState = host_check.OverallCheckState
 
 # --------------------------------------------------------------------
 # Helpers
@@ -66,7 +66,7 @@ def perform_check(
     files: Optional[Union[Tuple[str, str], List[Tuple[str, str]]]] = None,
     deps: Optional[List[str]] = None,
     failed_deps: Optional[List[str]] = None,
-) -> Tuple[host_check.OverallCheckState, str]:
+) -> Tuple[bool, str]:
     """
     Perform a single host check and return whether it succeeded and the output.
 
@@ -89,7 +89,7 @@ def perform_check(
     :param failed_deps:
         Any dependencies to treat as failed.
     :return:
-        The overall result of the check, and the output from the check.
+        The result of the check and the output from the check.
     """
     check = [c for c in CHECKS_BY_GROUP[group] if c.name == name][0]
     checks = []
@@ -178,14 +178,7 @@ def perform_check(
         lines = lines[len(deps) :]
         output = "".join(lines)
 
-    return result, output
-
-
-def pretty_print(msg: str) -> str:
-    dedent_msg = textwrap.dedent(msg)
-    if dedent_msg.startswith("ERROR"):
-        return dedent_msg
-    return textwrap.indent(dedent_msg, " ")
+    return result is OverallCheckState.ALL_SUCCEEDED, output
 
 
 # --------------------------------------------------------------------
@@ -247,7 +240,7 @@ Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared m
 XR platforms supported: xrd-control-plane, xrd-vrouter
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 0
 
     def test_plat_xrd(self, capsys):
@@ -265,7 +258,7 @@ Checks: {CONTROL_PLANE_CHECKS_STR}
 Host environment set up correctly for xrd-control-plane
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 0
 
     def test_plat_xrd_vrouter(self, capsys):
@@ -281,7 +274,7 @@ Checks: {VROUTER_CHECKS_STR}
 Host environment set up correctly for xrd-vrouter
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 0
 
     def test_extra_check_docker_plat(self, capsys):
@@ -309,7 +302,7 @@ Host environment set up correctly for xrd-control-plane
 Extra checks passed: docker
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 0
 
     def test_extra_check_xr_compose_plat(self, capsys):
@@ -337,7 +330,7 @@ Host environment set up correctly for xrd-control-plane
 Extra checks passed: xr-compose
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 0
 
     def test_all_extra_checks_plat(self, capsys):
@@ -369,7 +362,7 @@ Host environment set up correctly for xrd-control-plane
 Extra checks passed: docker, xr-compose
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 0
 
     def test_extra_check_docker(self, capsys):
@@ -406,7 +399,7 @@ XR platforms supported: xrd-control-plane, xrd-vrouter
 Extra checks passed: docker
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 0
 
     def test_extra_check_xr_compose(self, capsys):
@@ -443,7 +436,7 @@ XR platforms supported: xrd-control-plane, xrd-vrouter
 Extra checks passed: xr-compose
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 0
 
     def test_all_extra_checks(self, capsys):
@@ -486,7 +479,7 @@ XR platforms supported: xrd-control-plane, xrd-vrouter
 Extra checks passed: docker, xr-compose
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 0
 
     def test_plat_specified_check_failing(self, capsys):
@@ -506,7 +499,7 @@ Checks: {CONTROL_PLANE_CHECKS_STR}
 !! Host NOT set up correctly for xrd-control-plane !!
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 1
 
     def test_plat_specified_check_erroring(self, capsys):
@@ -527,7 +520,7 @@ Checks: {CONTROL_PLANE_CHECKS_STR}
 !! One or more checks could not be performed, see errors above !!
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 1
 
     def test_base_check_erroring(self, capsys):
@@ -559,7 +552,7 @@ Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared m
 !! One or more checks could not be performed, see errors above !!
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 1
 
     def test_no_plats_supported(self, capsys):
@@ -588,7 +581,7 @@ Checks: CPU extensions, RAM, Hugepages, Interface kernel driver, IOMMU, Shared m
 !! Host NOT set up correctly for any XR platforms !!
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 1
 
     def test_one_plat_supported(self, capsys):
@@ -618,7 +611,7 @@ XR platforms supported: xrd-control-plane
 XR platforms NOT supported: xrd-vrouter
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 0
 
     def test_extra_check_not_supported(self, capsys):
@@ -662,7 +655,7 @@ Extra checks passed: docker
 Extra checks failed: xr-compose
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 0
 
     def test_extra_check_failing(self, capsys):
@@ -697,13 +690,13 @@ Extra checks passed: docker
 Extra checks failed: xr-compose
 ==================================================================
 """
-        assert output == cli_output
+        assert textwrap.dedent(output) == cli_output
         assert exit_code == 1
 
     def test_unrecognized_arg(self, capsys):
         """Test running host-check with an unrecognized argument."""
         exit_code, output = self.run_host_check(capsys, ["philanthropy"])
-        assert output == ""
+        assert textwrap.dedent(output) == ""
         assert exit_code == 2
 
 
@@ -784,13 +777,15 @@ class TestArch(_CheckTestBase):
     def test_success(self, capsys):
         """Test the architecture being correct."""
         result, output = self.perform_check(capsys, cmd_effects="x86_64")
-        assert output == " PASS -- CPU architecture (x86_64)\n"
+        assert (
+            textwrap.dedent(output) == " PASS -- CPU architecture (x86_64)\n"
+        )
         assert result.is_success()
 
     def test_incorrect_arch(self, capsys):
         """Test the incorrect architecture case."""
         result, output = self.perform_check(capsys, cmd_effects="arm64")
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- CPU architecture
                      The CPU architecture is arm64, but XRd only supports: x86_64.
@@ -803,7 +798,7 @@ class TestArch(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=subprocess.SubprocessError
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- CPU architecture
                      Unable to check the CPU architecture with 'uname -m'.
@@ -823,13 +818,13 @@ class TestCPUCores(_CheckTestBase):
     def test_success(self, capsys):
         """Test the success case."""
         result, output = self.perform_check(capsys, cmd_effects="CPU(s): 16 ")
-        assert output == f" PASS -- CPU cores (16)\n"
+        assert textwrap.dedent(output) == f" PASS -- CPU cores (16)\n"
         assert result.is_success()
 
     def test_too_few_cpus(self, capsys):
         """Test there being too few available CPU cores."""
         result, output = self.perform_check(capsys, cmd_effects="CPU(s): 1 ")
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- CPU cores
                      The number of available CPU cores is 1,
@@ -843,7 +838,7 @@ class TestCPUCores(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="bananas taste awesome"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- CPU cores
                      Unable to parse the output from 'lscpu' -
@@ -858,7 +853,7 @@ class TestCPUCores(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=subprocess.SubprocessError
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- CPU cores
                      Error running 'lscpu' to check the number of available CPU cores.
@@ -872,7 +867,7 @@ class TestCPUCores(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=Exception("test exception")
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- CPU cores
                      Unexpected error: test exception
@@ -886,7 +881,7 @@ class TestCPUCores(_CheckTestBase):
             capsys,
             cmd_effects=subprocess.TimeoutExpired(cmd=self.cmds, timeout=5),
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- CPU cores
                      Unexpected error: Timed out while executing command: {" ".join(self.cmds)}
@@ -905,7 +900,7 @@ class TestKernelVersion(_CheckTestBase):
     def test_success(self, capsys):
         """Test the success case."""
         result, output = self.perform_check(capsys, cmd_effects="4.1")
-        assert output == " PASS -- Kernel version (4.1)\n"
+        assert textwrap.dedent(output) == " PASS -- Kernel version (4.1)\n"
         assert result.is_success()
 
     def test_subproc_error(self, capsys):
@@ -913,7 +908,7 @@ class TestKernelVersion(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=subprocess.SubprocessError
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Kernel version
                      Unable to check the kernel version - must be at least version 4.0
@@ -926,7 +921,7 @@ class TestKernelVersion(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="unexpected output"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Kernel version
                      Unable to check the kernel version - must be at least version 4.0
@@ -937,7 +932,7 @@ class TestKernelVersion(_CheckTestBase):
     def test_old_version(self, capsys):
         """Test the version being too old."""
         result, output = self.perform_check(capsys, cmd_effects="3.9.8")
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Kernel version
                      The kernel version is 3.9, but at least version 4.0 is required.
@@ -950,7 +945,7 @@ class TestKernelVersion(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="4.18.0-240.el8"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Kernel version
                      The operating system appears to be RHEL/CentOS 8.3 (kernel version 4.18.0-240),
@@ -965,7 +960,7 @@ class TestKernelVersion(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="4.18.0-193.el8"
         )
-        assert output == " PASS -- Kernel version (4.18)\n"
+        assert textwrap.dedent(output) == " PASS -- Kernel version (4.18)\n"
         assert result.is_success()
 
     def test_generic_os_with_rhel83_kernel_version(self, capsys):
@@ -973,7 +968,7 @@ class TestKernelVersion(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="4.18.0-240.generic"
         )
-        assert output == " PASS -- Kernel version (4.18)\n"
+        assert textwrap.dedent(output) == " PASS -- Kernel version (4.18)\n"
         assert result.is_success()
 
 
@@ -991,7 +986,7 @@ class TestBaseKernelModules(_CheckTestBase):
     def test_success(self, capsys):
         """Test the success case."""
         result, output = self.perform_check(capsys, cmd_effects=["", ""])
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              PASS -- Base kernel modules
                      Installed module(s): dummy, nf_tables
@@ -1004,7 +999,7 @@ class TestBaseKernelModules(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=["", subprocess.SubprocessError(1, "")]
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- Base kernel modules
                      Missing kernel module(s): nf_tables
@@ -1019,7 +1014,7 @@ class TestBaseKernelModules(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=[subprocess.SubprocessError(1, ""), ""]
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- Base kernel modules
                      Missing kernel module(s): dummy
@@ -1034,7 +1029,7 @@ class TestBaseKernelModules(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=["", Exception("test exception")]
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- Base kernel modules
                      Unexpected error: test exception
@@ -1048,7 +1043,7 @@ class TestBaseKernelModules(_CheckTestBase):
             capsys,
             cmd_effects=subprocess.TimeoutExpired(cmd=self.cmds, timeout=5),
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- Base kernel modules
                      Unexpected error: Timed out while executing command: {" ".join(self.cmds)}
@@ -1059,7 +1054,7 @@ class TestBaseKernelModules(_CheckTestBase):
     def test_failed_dependency(self, capsys):
         """Test a dependency failure."""
         result, output = self.perform_check(capsys, failed_deps=self.deps)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              SKIP -- Base kernel modules
                      Skipped due to failed checks: Kernel version
@@ -1103,7 +1098,7 @@ class TestCgroups(_CheckTestBase):
                 mock.Mock(returncode=0),
             ],
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              PASS -- Cgroups (v1)
             """
@@ -1116,7 +1111,7 @@ class TestCgroups(_CheckTestBase):
             capsys,
             cmd_effects=[mock.Mock(returncode=1), mock.Mock(returncode=1)],
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Cgroups
                      Error trying to determine the cgroups version - /sys/fs/cgroup is expected to
@@ -1131,7 +1126,7 @@ class TestCgroups(_CheckTestBase):
             result, output = self.perform_check(
                 capsys, cmd_effects=[mock.Mock(returncode=0), None]
             )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              INFO -- Cgroups
                      Cgroups v2 is in use - this is not supported for production environments.
@@ -1144,7 +1139,7 @@ class TestCgroups(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=subprocess.SubprocessError
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Cgroups
                      Error trying to determine the cgroups version - /sys/fs/cgroup is expected to
@@ -1167,7 +1162,7 @@ class TestCgroups(_CheckTestBase):
                 mock.Mock(returncode=0),
             ],
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Cgroups
                      These cgroup mounts do not exist on the host: systemd.
@@ -1193,7 +1188,7 @@ class TestCgroups(_CheckTestBase):
                 mock.Mock(returncode=0),
             ],
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Cgroups
                      These cgroup mounts do not exist on the host: pids.
@@ -1216,7 +1211,7 @@ class TestCgroups(_CheckTestBase):
                 mock.Mock(returncode=0),
             ],
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Cgroups
                      These cgroup mounts do not exist on the host: systemd, cpu.
@@ -1238,7 +1233,7 @@ class _TestInotifyLimitsBase(_CheckTestBase):
     def test_success(self, capsys):
         """Test the success case."""
         result, output = self.perform_check(capsys, read_effects="10000000")
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              PASS -- {self.check_name}
                      10000000 - this is expected to be sufficient for 2500 XRd instance(s).
@@ -1249,7 +1244,7 @@ class _TestInotifyLimitsBase(_CheckTestBase):
     def test_too_low(self, capsys):
         """Test the limit being too low."""
         result, output = self.perform_check(capsys, read_effects="3000")
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- {self.check_name}
                      The kernel parameter fs.inotify.{self.inotify_param} is set to 3000 but
@@ -1266,7 +1261,7 @@ class _TestInotifyLimitsBase(_CheckTestBase):
     def test_warning_level(self, capsys):
         """Test the limit being not too low but recommended to be higher."""
         result, output = self.perform_check(capsys, read_effects="7000")
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              WARN -- {self.check_name}
                      The kernel parameter fs.inotify.{self.inotify_param} is set to 7000 -
@@ -1283,7 +1278,7 @@ class _TestInotifyLimitsBase(_CheckTestBase):
     def test_error(self, capsys):
         """Test error being raised."""
         result, output = self.perform_check(capsys, read_effects=Exception)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- {self.check_name}
                      Failed to check inotify resource limits by reading
@@ -1327,7 +1322,10 @@ class TestCorePattern(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects="no leading pipe"
         )
-        assert output == " INFO -- Core pattern (core files managed by XR)\n"
+        assert (
+            textwrap.dedent(output)
+            == " INFO -- Core pattern (core files managed by XR)\n"
+        )
         assert result.is_success()
 
     def test_managed_by_host(self, capsys):
@@ -1342,7 +1340,7 @@ class TestCorePattern(_CheckTestBase):
     def test_error(self, capsys):
         """Test error being raised."""
         result, output = self.perform_check(capsys, read_effects=Exception)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              INFO -- Core pattern
                      Failed to read /proc/sys/kernel/core_pattern - unable to determine
@@ -1362,13 +1360,15 @@ class TestASLR(_CheckTestBase):
     def test_success(self, capsys):
         """Test the success case."""
         result, output = self.perform_check(capsys, read_effects="2")
-        assert output == " PASS -- ASLR (full randomization)\n"
+        assert (
+            textwrap.dedent(output) == " PASS -- ASLR (full randomization)\n"
+        )
         assert result.is_success()
 
     def test_read_error(self, capsys):
         """Test the limit being too low."""
         result, output = self.perform_check(capsys, read_effects=Exception)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- ASLR
                      Failed to read /proc/sys/kernel/randomize_va_space, which controls ASLR
@@ -1386,7 +1386,7 @@ class TestASLR(_CheckTestBase):
     def test_unexpected_value(self, capsys):
         """Test the file containing an unexpected value."""
         result, output = self.perform_check(capsys, read_effects="unexpected")
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- ASLR
                      Failed to read /proc/sys/kernel/randomize_va_space, which controls ASLR
@@ -1404,7 +1404,7 @@ class TestASLR(_CheckTestBase):
     def test_not_enabled(self, capsys):
         """Test the limit being not too low but recommended to be higher."""
         result, output = self.perform_check(capsys, read_effects="1")
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              WARN -- ASLR
                      The kernel paramater kernel.randomize_va_space, which controls ASLR
@@ -1432,7 +1432,7 @@ class TestLSMs(_CheckTestBase):
         Test when config files read, they indicate LSMs are disabled or not
         installed.
         """
-        expected = pretty_print(
+        expected = textwrap.dedent(
             f"""\
              INFO -- Linux Security Modules (No LSMs are enabled)
             """
@@ -1440,13 +1440,13 @@ class TestLSMs(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects=[FileNotFoundError, FileNotFoundError]
         )
-        assert output == expected
+        assert textwrap.dedent(output) == expected
         assert result.is_success()
 
         result, output = self.perform_check(
             capsys, read_effects=["", "SELINUX=disabled"]
         )
-        assert output == expected
+        assert textwrap.dedent(output) == expected
         assert result.is_success()
 
     def test_apparmor_enabled(self, capsys):
@@ -1455,7 +1455,7 @@ class TestLSMs(_CheckTestBase):
             capsys,
             read_effects=["nvidia_modprobe (enforce)", FileNotFoundError],
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              WARN -- Linux Security Modules
                      AppArmor is enabled. XRd is currently unable to run with the
@@ -1468,7 +1468,7 @@ class TestLSMs(_CheckTestBase):
 
     def test_selinux_enabled(self, capsys):
         """Test SELinux config set to enabled."""
-        expected = pretty_print(
+        expected = textwrap.dedent(
             f"""\
              INFO -- Linux Security Modules
                      SELinux is enabled. XRd is currently unable to run with the
@@ -1479,13 +1479,13 @@ class TestLSMs(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects=[FileNotFoundError, "SELINUX=enforcing"]
         )
-        assert output == expected
+        assert textwrap.dedent(output) == expected
         assert result.is_success()
 
         result, output = self.perform_check(
             capsys, read_effects=["", "SELINUX=enforcing"]
         )
-        assert output == expected
+        assert textwrap.dedent(output) == expected
         assert result.is_success()
 
     def test_both_enabled(self, capsys):
@@ -1494,7 +1494,7 @@ class TestLSMs(_CheckTestBase):
             capsys,
             read_effects=["nvidia_modprobe (enforce)", "SELINUX=enforcing"],
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              WARN -- Linux Security Modules
                      AppArmor is enabled. XRd is currently unable to run with the
@@ -1546,7 +1546,7 @@ class TestRealtimeGroupSched(_CheckTestBase):
             "host_check._get_cgroup_version", return_value=1
         ), mock.patch("os.path.exists", return_value=True):
             result, output = self.perform_check(capsys, read_effects=Exception)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Real-time Group Scheduling
                      Failed to read /proc/sys/kernel/sched_rt_runtime_us, unable to check if
@@ -1568,7 +1568,7 @@ class TestRealtimeGroupSched(_CheckTestBase):
             "host_check._get_cgroup_version", return_value=1
         ), mock.patch("os.path.exists", return_value=True):
             result, output = self.perform_check(capsys, read_effects="950000")
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Real-time Group Scheduling
                      The kernel parameter kernel.sched_rt_runtime_us is set to 950000
@@ -1614,7 +1614,7 @@ class TestRealtimeGroupSched(_CheckTestBase):
             "host_check._get_cgroup_version", return_value=2
         ), mock.patch("os.path.exists", return_value=True):
             result, output = self.perform_check(capsys, read_effects="950000")
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Real-time Group Scheduling
                      The kernel parameter kernel.sched_rt_runtime_us is set to 950000
@@ -1658,7 +1658,10 @@ class TestSocketParameters(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects=minimum_values
         )
-        assert output == " PASS -- Socket kernel parameters (valid settings)\n"
+        assert (
+            textwrap.dedent(output)
+            == " PASS -- Socket kernel parameters (valid settings)\n"
+        )
         assert result.is_success()
 
     def test_higher_values(self, capsys):
@@ -1672,7 +1675,10 @@ class TestSocketParameters(_CheckTestBase):
             "67118864",
         ]
         result, output = self.perform_check(capsys, read_effects=higher_values)
-        assert output == " PASS -- Socket kernel parameters (valid settings)\n"
+        assert (
+            textwrap.dedent(output)
+            == " PASS -- Socket kernel parameters (valid settings)\n"
+        )
         assert result.is_success()
 
     def test_lower_values(self, capsys):
@@ -1686,7 +1692,7 @@ class TestSocketParameters(_CheckTestBase):
             "212992",
         ]
         result, output = self.perform_check(capsys, read_effects=lower_values)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              WARN -- Socket kernel parameters
                      The kernel socket parameters are insufficient for running XRd in a
@@ -1729,7 +1735,7 @@ class TestSocketParameters(_CheckTestBase):
             Exception,
         ]
         result, output = self.perform_check(capsys, read_effects=error_values)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- Socket kernel parameters
                      Failed to read socket kernel parameter /proc/sys/net/core/rmem_max.
@@ -1750,7 +1756,10 @@ class TestUDPParameters(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects="1124736 10000000 67108864"
         )
-        assert output == " PASS -- UDP kernel parameters (valid settings)\n"
+        assert (
+            textwrap.dedent(output)
+            == " PASS -- UDP kernel parameters (valid settings)\n"
+        )
         assert result.is_success()
 
     def test_higher_values(self, capsys):
@@ -1758,7 +1767,10 @@ class TestUDPParameters(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects="1124737 20000000 67108868"
         )
-        assert output == " PASS -- UDP kernel parameters (valid settings)\n"
+        assert (
+            textwrap.dedent(output)
+            == " PASS -- UDP kernel parameters (valid settings)\n"
+        )
         assert result.is_success()
 
     def test_lower_values(self, capsys):
@@ -1767,7 +1779,7 @@ class TestUDPParameters(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects="767055 1022741 1534110"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              WARN -- UDP kernel parameters
                      The kernel UDP parameters are insufficient for running XRd in a
@@ -1792,7 +1804,7 @@ class TestUDPParameters(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects="1124736 1022741 1534110"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              WARN -- UDP kernel parameters
                      The kernel UDP parameters are insufficient for running XRd in a
@@ -1817,7 +1829,7 @@ class TestUDPParameters(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects="1124736 10000000 1534110"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              WARN -- UDP kernel parameters
                      The kernel UDP parameters are insufficient for running XRd in a
@@ -1842,7 +1854,7 @@ class TestUDPParameters(_CheckTestBase):
     def test_read_failure(self, capsys):
         """Test read failure on socket parameter"""
         result, output = self.perform_check(capsys, read_effects=Exception)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- UDP kernel parameters
                      Failed to read UDP kernel parameter /proc/sys/net/ipv4/udp_mem.
@@ -1871,7 +1883,7 @@ Mem:    17048223744 14166241280  2647126016    18145280   234856448  2745040896
 Swap:   31798079488  2008911872 29789167616
         """
         result, output = self.perform_check(capsys, cmd_effects=cmd_output)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              PASS -- RAM
                      Available RAM is 2.6 GiB.
@@ -1887,7 +1899,7 @@ Swap:   31798079488  2008911872 29789167616
         result, output = self.perform_check(
             capsys, cmd_effects=subprocess.SubprocessError
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- RAM
                      The command 'free -b' failed - unable to determine the available RAM on
@@ -1902,7 +1914,7 @@ Swap:   31798079488  2008911872 29789167616
         result, output = self.perform_check(
             capsys, cmd_effects="unexpected output"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- RAM
                      Failed to parse the output from 'free -b' - unable to determine the
@@ -1920,7 +1932,7 @@ Mem:    17048223744 14166241280  2647126016    18145280   234856448  1745040896
 Swap:   31798079488  2008911872 29789167616
         """
         result, output = self.perform_check(capsys, cmd_effects=cmd_output)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              WARN -- RAM
                      The available RAM on the host (1.6 GiB) may be insufficient to run XRd.
@@ -1935,7 +1947,7 @@ Swap:   31798079488  2008911872 29789167616
         result, output = self.perform_check(
             capsys, cmd_effects=Exception("test exception")
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- RAM
                      Unexpected error: test exception
@@ -1956,13 +1968,16 @@ class TestCPUExtensions(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="Flags: ssse3 sse4_1 sse4_2"
         )
-        assert output == f" PASS -- CPU extensions (sse4_1, sse4_2, ssse3)\n"
+        assert (
+            textwrap.dedent(output)
+            == f" PASS -- CPU extensions (sse4_1, sse4_2, ssse3)\n"
+        )
         assert result.is_success()
 
     def test_parse_error(self, capsys):
         """Test the case where the CPU extensions cannot be parsed."""
         result, output = self.perform_check(capsys, cmd_effects="no match")
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- CPU extensions
                      Unable to parse the output from 'lscpu' - unable to check
@@ -1975,7 +1990,7 @@ class TestCPUExtensions(_CheckTestBase):
     def test_missing_extensions(self, capsys):
         """Test some extensions being missing."""
         result, output = self.perform_check(capsys, cmd_effects="Flags: ssse3")
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- CPU extensions
                      Missing CPU extension(s): sse4_1, sse4_2
@@ -1989,7 +2004,7 @@ class TestCPUExtensions(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=subprocess.SubprocessError
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- CPU extensions
                      Unable to parse the output from 'lscpu' - unable to check
@@ -2004,7 +2019,7 @@ class TestCPUExtensions(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=Exception("test exception")
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- CPU extensions
                      Unexpected error: test exception
@@ -2032,7 +2047,7 @@ class TestHugepages(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects=hugepages_data
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              PASS -- Hugepages (3 x 1GiB)
             """
@@ -2051,7 +2066,7 @@ class TestHugepages(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects=hugepages_data
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              WARN -- Hugepages
                      2MiB hugepages are available, but only 1GiB hugepages are
@@ -2072,7 +2087,7 @@ class TestHugepages(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects=hugepages_data
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Hugepages
                      3MiB hugepages are available, but XRd requires 1GiB hugepages.
@@ -2095,7 +2110,7 @@ class TestHugepages(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects=hugepages_data
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Hugepages
                      Only 2.0GiB of hugepage memory available, but XRd
@@ -2119,7 +2134,7 @@ class TestHugepages(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects=hugepages_data
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Hugepages
                      2MiB hugepages are available, but only 1GiB hugepages are
@@ -2142,7 +2157,7 @@ class TestHugepages(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects=hugepages_data
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Hugepages
                      Hugepages are not enabled. These are required for XRd to function correctly.
@@ -2155,7 +2170,7 @@ class TestHugepages(_CheckTestBase):
     def test_mem_oserror(self, capsys):
         """Test an OS error being raised when trying to read from /proc/meminfo."""
         result, output = self.perform_check(capsys, read_effects=OSError)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Hugepages
                      Unable to parse the contents of /proc/meminfo - unable to check
@@ -2169,7 +2184,7 @@ class TestHugepages(_CheckTestBase):
     def test_value_error(self, capsys):
         """Test a value error being raised."""
         result, output = self.perform_check(capsys, read_effects=ValueError)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Hugepages
                      Unable to parse the contents of /proc/meminfo - unable to check
@@ -2185,7 +2200,7 @@ class TestHugepages(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects=Exception("test exception")
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Hugepages
                      Unexpected error: test exception
@@ -2215,7 +2230,7 @@ class TestGDPKernelDriver(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=["", None, "", None, None, None]
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              PASS -- Interface kernel driver
                      Loaded PCI drivers: vfio-pci, igb_uio
@@ -2237,7 +2252,7 @@ class TestGDPKernelDriver(_CheckTestBase):
                 None,
             ],
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              PASS -- Interface kernel driver
                      Loaded PCI drivers: vfio-pci, igb_uio
@@ -2259,7 +2274,7 @@ class TestGDPKernelDriver(_CheckTestBase):
                 "",
             ],
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- Interface kernel driver
                      None of the expected PCI drivers are loaded.
@@ -2282,7 +2297,7 @@ class TestGDPKernelDriver(_CheckTestBase):
                 subprocess.SubprocessError,
             ],
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- Interface kernel driver
                      No PCI drivers are loaded or installed.
@@ -2305,7 +2320,7 @@ class TestGDPKernelDriver(_CheckTestBase):
                 "",
             ],
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              INFO -- Interface kernel driver
                      The following PCI drivers are installed but not loaded: igb_uio.
@@ -2328,7 +2343,7 @@ class TestGDPKernelDriver(_CheckTestBase):
                 None,
             ],
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              INFO -- Interface kernel driver
                      The following PCI drivers are installed but not loaded: vfio-pci.
@@ -2351,7 +2366,7 @@ class TestGDPKernelDriver(_CheckTestBase):
                 "",
             ],
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- Interface kernel driver
                      None of the expected PCI drivers are loaded.
@@ -2366,7 +2381,7 @@ class TestGDPKernelDriver(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=Exception("test exception")
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- Interface kernel driver
                      Unexpected error: test exception
@@ -2423,7 +2438,7 @@ pci@0000:00:01.0  device2     network    Ethernet interface
                 ],
                 read_effects="N",
             )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              PASS -- IOMMU
                      IOMMU enabled for vfio-pci with the following PCI device(s):
@@ -2454,7 +2469,7 @@ pci@0000:00:1f.2  docker0     network    Ethernet interface
                 ],
                 read_effects="N",
             )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              WARN -- IOMMU
                      IOMMU enabled for vfio-pci, but no network PCI devices found.
@@ -2484,7 +2499,7 @@ pci@0000:00:1f.2  docker0     network    Ethernet interface
                 ],
                 read_effects="N",
             )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- IOMMU
                      The cmd 'lshw -businfo -c network' failed - unable to
@@ -2519,7 +2534,7 @@ Bus info          Device      Class      Description
                 ],
                 read_effects="N",
             )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              WARN -- IOMMU (no PCI network devices found)
             """
@@ -2539,7 +2554,7 @@ Bus info          Device      Class      Description
                 ],
                 read_effects="N",
             )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- IOMMU
                      Unable to check if IOMMU is enabled by listing /sys/class/iommu/*/devices/*.
@@ -2561,7 +2576,7 @@ Bus info          Device      Class      Description
                 ],
                 read_effects="N",
             )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              WARN -- IOMMU
                      The kernel module vfio-pci cannot be used, as IOMMU is not enabled.
@@ -2582,7 +2597,7 @@ Bus info          Device      Class      Description
             ],
             read_effects="Y",
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              WARN -- IOMMU
                      vfio-pci is set up in no-IOMMU mode, but IOMMU is recommended for security.
@@ -2626,7 +2641,7 @@ pci@0000:00:01.0  device2     network    Ethernet interface
                 ],
                 read_effects=OSError,
             )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              PASS -- IOMMU
                      IOMMU enabled for vfio-pci with the following PCI device(s):
@@ -2648,7 +2663,7 @@ pci@0000:00:01.0  device2     network    Ethernet interface
             ],
             read_effects=Exception("test exception"),
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- IOMMU
                      Unexpected error: test exception
@@ -2659,7 +2674,7 @@ pci@0000:00:01.0  device2     network    Ethernet interface
     def test_failed_dependency(self, capsys):
         """Test a dependency failure."""
         result, output = self.perform_check(capsys, failed_deps=self.deps)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              SKIP -- IOMMU
                      Skipped due to failed checks: Interface kernel driver
@@ -2676,7 +2691,7 @@ pci@0000:00:01.0  device2     network    Ethernet interface
                 subprocess.SubprocessError,
             ],
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              INFO -- IOMMU (vfio-pci driver unavailable)
             """
@@ -2691,7 +2706,7 @@ pci@0000:00:01.0  device2     network    Ethernet interface
         result, output = self.perform_check(
             capsys, cmd_effects=["", None, "", None], read_effects="Y"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              INFO -- IOMMU
                      vfio-pci is set up in no-IOMMU mode, but IOMMU is recommended for security.
@@ -2710,13 +2725,16 @@ class TestSharedMemPageMaxSize(_CheckTestBase):
     def test_success(self, capsys):
         """Test the success case."""
         result, output = self.perform_check(capsys, read_effects="2147483648")
-        assert output == " PASS -- Shared memory pages max size (2.0 GiB)\n"
+        assert (
+            textwrap.dedent(output)
+            == " PASS -- Shared memory pages max size (2.0 GiB)\n"
+        )
         assert result.is_success()
 
     def test_oserror(self, capsys):
         """Test the OS error case."""
         result, output = self.perform_check(capsys, read_effects=OSError)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Shared memory pages max size
                      Unable to read the contents of /proc/sys/kernel/shmmax - unable to
@@ -2729,7 +2747,7 @@ class TestSharedMemPageMaxSize(_CheckTestBase):
     def test_failure(self, capsys):
         """Test the OS error case."""
         result, output = self.perform_check(capsys, read_effects="1073741824")
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Shared memory pages max size
                      The maximum size of shared memory pages is 1.0 GiB,
@@ -2743,7 +2761,7 @@ class TestSharedMemPageMaxSize(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects="not an integer"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Shared memory pages max size
                      Unable to parse the contents of /proc/sys/kernel/shmmax - unable to
@@ -2758,7 +2776,7 @@ class TestSharedMemPageMaxSize(_CheckTestBase):
         result, output = self.perform_check(
             capsys, read_effects=Exception("test exception")
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Shared memory pages max size
                      Unexpected error: test exception
@@ -2784,7 +2802,10 @@ class TestDockerClient(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="Docker version 18.0.4"
         )
-        assert output == " PASS -- Docker client (version 18.0.4)\n"
+        assert (
+            textwrap.dedent(output)
+            == " PASS -- Docker client (version 18.0.4)\n"
+        )
         assert result.is_success()
 
     def test_subproc_error(self, capsys):
@@ -2792,7 +2813,7 @@ class TestDockerClient(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=subprocess.SubprocessError
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Docker client
                      Docker client not correctly installed on the host (checked with
@@ -2808,7 +2829,7 @@ class TestDockerClient(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="unexpected output"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Docker client
                      Unable to parse Docker client version from 'docker --version'.
@@ -2822,7 +2843,7 @@ class TestDockerClient(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="Docker version 17.11"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Docker client
                      Docker version must be at least 18.0, current client version is 17.11.
@@ -2836,7 +2857,7 @@ class TestDockerClient(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=Exception("test exception")
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Docker client
                      Unexpected error: test exception
@@ -2856,7 +2877,10 @@ class TestDockerDaemon(_CheckTestBase):
     def test_success(self, capsys):
         """Test the success case."""
         result, output = self.perform_check(capsys, cmd_effects='"18.0.4"')
-        assert output == " PASS -- Docker daemon (running, version 18.0.4)\n"
+        assert (
+            textwrap.dedent(output)
+            == " PASS -- Docker daemon (running, version 18.0.4)\n"
+        )
         assert result.is_success()
 
     def test_subproc_error(self, capsys):
@@ -2864,7 +2888,7 @@ class TestDockerDaemon(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=subprocess.SubprocessError
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Docker daemon
                      Unable to connect to the Docker daemon (checked with
@@ -2880,7 +2904,7 @@ class TestDockerDaemon(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="unexpected output"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Docker daemon
                      Unable to parse Docker server version from
@@ -2893,7 +2917,7 @@ class TestDockerDaemon(_CheckTestBase):
     def test_old_version(self, capsys):
         """Test the version being too old."""
         result, output = self.perform_check(capsys, cmd_effects='"17.11"')
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Docker daemon
                      Docker version must be at least 18.0, current server version is 17.11.
@@ -2907,7 +2931,7 @@ class TestDockerDaemon(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=Exception("test exception")
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Docker daemon
                      Unexpected error: test exception
@@ -2918,7 +2942,7 @@ class TestDockerDaemon(_CheckTestBase):
     def test_failed_dependency(self, capsys):
         """Test a dependency failure."""
         result, output = self.perform_check(capsys, failed_deps=self.deps)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              SKIP -- Docker daemon
                      Skipped due to failed checks: Docker client
@@ -2940,7 +2964,7 @@ class TestDtypeSupport(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="Supports d_type: true"
         )
-        assert output == " PASS -- Docker supports d_type\n"
+        assert textwrap.dedent(output) == " PASS -- Docker supports d_type\n"
         assert result.is_success()
 
     def test_subproc_error(self, capsys):
@@ -2948,7 +2972,7 @@ class TestDtypeSupport(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=subprocess.SubprocessError
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Docker supports d_type
                      'docker info' command failed.
@@ -2963,7 +2987,7 @@ class TestDtypeSupport(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="unexpected output"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Docker supports d_type
                      Docker is using a backing filesystem that does not support d_type
@@ -2978,7 +3002,7 @@ class TestDtypeSupport(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=Exception("test exception")
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- Docker supports d_type
                      Unexpected error: test exception
@@ -2989,7 +3013,7 @@ class TestDtypeSupport(_CheckTestBase):
     def test_failed_dependency(self, capsys):
         """Test a dependency failure."""
         result, output = self.perform_check(capsys, failed_deps=self.deps)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              SKIP -- Docker supports d_type
                      Skipped due to failed checks: Docker daemon
@@ -3015,7 +3039,10 @@ class TestDockerCompose(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="docker-compose version 1.18.0"
         )
-        assert output == " PASS -- docker-compose (version 1.18.0)\n"
+        assert (
+            textwrap.dedent(output)
+            == " PASS -- docker-compose (version 1.18.0)\n"
+        )
         assert result.is_success()
 
     def test_subproc_error(self, capsys):
@@ -3023,7 +3050,7 @@ class TestDockerCompose(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=subprocess.SubprocessError
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- docker-compose
                      Docker Compose not found (checked with 'docker-compose --version').
@@ -3038,7 +3065,7 @@ class TestDockerCompose(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="unexpected output"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- docker-compose
                      Unable to parse Docker Compose version, at least version 1.18 is required.
@@ -3051,7 +3078,7 @@ class TestDockerCompose(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects="docker-compose version 1.17.10"
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- docker-compose
                      Docker Compose version must be at least 1.18, current version is 1.17.10.
@@ -3065,7 +3092,7 @@ class TestDockerCompose(_CheckTestBase):
         result, output = self.perform_check(
             capsys, cmd_effects=Exception("test exception")
         )
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             """\
              FAIL -- docker-compose
                      Unexpected error: test exception
@@ -3084,14 +3111,14 @@ class TestPyYAML(_CheckTestBase):
         """Test the success case."""
         with mock.patch("builtins.__import__"):
             result, output = self.perform_check(capsys)
-        assert output == f" PASS -- PyYAML (installed)\n"
+        assert textwrap.dedent(output) == f" PASS -- PyYAML (installed)\n"
         assert result.is_success()
 
     def test_unavailable(self, capsys):
         """Test yaml not being available."""
         with mock.patch("builtins.__import__", side_effect=ImportError):
             result, output = self.perform_check(capsys)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- PyYAML
                      PyYAML Python package not installed - required for running xr-compose.
@@ -3106,7 +3133,7 @@ class TestPyYAML(_CheckTestBase):
             "builtins.__import__", side_effect=Exception("test exception")
         ):
             result, output = self.perform_check(capsys)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- PyYAML
                      Unexpected error: test exception
@@ -3128,13 +3155,15 @@ class TestBridgeIptables(_CheckTestBase):
     def test_success(self, capsys):
         """Test the success case."""
         result, output = self.perform_check(capsys, read_effects=["0", "0"])
-        assert output == " PASS -- Bridge iptables (disabled)\n"
+        assert (
+            textwrap.dedent(output) == " PASS -- Bridge iptables (disabled)\n"
+        )
         assert result.is_success()
 
     def test_not_disabled(self, capsys):
         """Test bridge iptables not being disabled."""
         result, output = self.perform_check(capsys, read_effects=["0", "1"])
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
              FAIL -- Bridge iptables
                      For xr-compose to be able to use Docker bridges, bridge IP tables must
@@ -3155,7 +3184,7 @@ class TestBridgeIptables(_CheckTestBase):
     def test_error(self, capsys):
         """Test error being raised."""
         result, output = self.perform_check(capsys, read_effects=Exception)
-        assert output == pretty_print(
+        assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             ERROR -- Bridge iptables
                      Failed to read iptables settings under /proc/sys/net/bridge/.


### PR DESCRIPTION
Currently, `host-check` warns if unable to perform a check. This can be unclear to users, so add a new `ERROR` case for this.

## Description of code changes
* Added `CheckState.ERROR`
* Renamed `CheckState.is_error()` method to `CheckState.is_failure()` to distinguish between failure and error cases
* Updated code to use the error check state when checks fail to run
* Updated the output message at the end of the script
* Updated `test_host_check.py`
* Updated `CHANGELOG.md`

## Testing
`commit-check` script passed without errors.
Code coverage is 98% for `host-check`.