### PR TITLE
Meta: Ensure releases are created for changelog versions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+### Summary
+
+*Main description goes here.*
+
+
+### Checklist
+
+<!-- See CONTRIBUTING.md. -->
+
+- [ ] Changelog updated (or not required)
+  <!-- Is there any reason a user might care about the change?
+       Have you changed any files that go in the release tarball?
+       New GH release must be created after merging if new version added to the changelog. 
+  -->
+- [ ] Static analysis and tests passing
+   - Use `commit-check` script, or check GitHub Actions status.

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -18,7 +18,7 @@ jobs:
           changelog_version=$(grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -n1)
           echo "Top version found in CHANGELOG.md: $changelog_version"
           release_version=$(curl https://api.github.com/repos/ios-xr/xrd-tools/releases/latest -s | jq .tag_name | tr -d '"')
-          echo "Latest release version from https://api.github.com/repos/ios-xr/xrd-tools/releases/latest: $release_version"
+          echo "Latest release version from 'https://api.github.com/repos/ios-xr/xrd-tools/releases/latest': $release_version"
           if [[ $release_version != $changelog_version ]]; then
               echo "No release for $changelog_version (found in CHANGELOG.md), latest is $release_version" >&2
               exit 1

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -2,9 +2,6 @@ name: check-release
 on:
   schedule:
     - cron: "0 8 * * *"
-  push:
-    branches:
-      - "ensure-release"
 jobs:
   check-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,0 +1,18 @@
+name: check-release
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  push:
+    branches:
+      - "ensure-release"
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get latest release version
+        run: |
+          echo "Release version: ${{github.event.release.tag_name}}"

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -6,13 +6,22 @@ on:
     branches:
       - "ensure-release"
 jobs:
-  create-release:
+  check-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@main
         with:
           fetch-depth: 0
 
-      - name: Get latest release version
+      - name: Check latest version in CHANGELOG.md has a corresponding release
         run: |
-          echo "Release version: ${{github.event.release.tag_name}}"
+          changelog_version=$(grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -n1)
+          echo "Top version found in CHANGELOG.md: $changelog_version"
+          release_version=$(curl https://api.github.com/repos/ios-xr/xrd-tools/releases/latest -s | jq .tag_name | tr -d '"')
+          echo "Latest release version from https://api.github.com/repos/ios-xr/xrd-tools/releases/latest: $release_version"
+          if [[ $release_version != $changelog_version ]]; then
+              echo "No release for $changelog_version (found in CHANGELOG.md), latest is $release_version" >&2
+              exit 1
+          else
+              echo "Versions match"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@main
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-    branches:
-      - 'gh-actions-release*'
 jobs:
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/sa.yml
+++ b/.github/workflows/sa.yml
@@ -10,9 +10,6 @@ on:
       - 'docs/**'
       - 'templates/**'
       - 'commit-check'
-  push:
-    branches:
-      - 'gh-actions*'
 jobs:
   python:
     runs-on: ubuntu-latest

--- a/.github/workflows/sa.yml
+++ b/.github/workflows/sa.yml
@@ -28,7 +28,7 @@ jobs:
             cmd: 'mypy'
     name: 'python-sa (${{ matrix.name }})'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     name: 'bash-sa (shellcheck)'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ["3.7", "3.11"]
     name: 'tests (python ${{ matrix.python-version }})'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,16 +10,13 @@ on:
       - 'docs/**'
       - 'templates/**'
       - 'commit-check'
-  push:
-    branches:
-      - 'gh-actions*'
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.7", "3.11"]
     name: 'tests (python ${{ matrix.python-version }})'
     steps:
       - uses: actions/checkout@master
@@ -37,4 +34,4 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run UT
-        run: pytest tests/ -v
+        run: pytest tests/ -v --cov scripts/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Check release](https://github.com/ios-xr/xrd-tools/actions/workflows/check-release.yml/badge.svg)](https://github.com/ios-xr/xrd-tools/actions/workflows/check-release.yml)
+
 # XRd Tools
 
 This repository contains tools for working with XRd containers.


### PR DESCRIPTION
### Summary

- Added new GH actions workflow for checking the latest changelog version matches the latest release version, runs once a day.
  - Successful run: https://github.com/ios-xr/xrd-tools/actions/runs/5024446124/jobs/9010179057
  - Failing run (using new version in changelog): https://github.com/ios-xr/xrd-tools/actions/runs/5024396708/jobs/9010073914
- Updated other GH action workflows to use newer versions of things (e.g. python3.11)
- Added PR template (in use here)

### Checklist

<!-- See CONTRIBUTING.md. -->

- [x] Changelog updated (or not required)
  <!-- Is there any reason a user might care about the change?
       Have you changed any files that go in the release tarball?
       New GH release must be created after merging if new version added to the changelog. 
  -->
- [x] Static analysis and tests passing
   - Use `commit-check` script, or check GitHub Actions status.