### PR TITLE
Handle dirty docker version

### DIFF
--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1226,7 +1226,7 @@ def check_docker_daemon() -> CheckFuncReturn:
             f"See installation instructions at https://docs.docker.com/engine/install/.",
         )
 
-    version_match = re.match(r'"(\d+\.\d+(?:\.\d+)?)"', version_str)
+    version_match = re.match(r'"(\d+\.\d+(?:\.\d+)?)(?:\+.*)?"', version_str)
     if not version_match:
         return (
             CheckState.WARNING,

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -2792,6 +2792,12 @@ class TestDockerDaemon(_CheckTestBase):
         assert output == "PASS -- Docker daemon (running, version 18.0.4)\n"
         assert success
 
+    def test_dirty_version(self, capsys):
+        """Test success with a dirty version number."""
+        success, output = self.perform_check(capsys, cmd_effects='"20.1+azure"')
+        assert output == "PASS -- Docker daemon (running, version 20.1)\n"
+        assert success
+
     def test_subproc_error(self, capsys):
         """Test a subprocess error being raised."""
         success, output = self.perform_check(

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -2794,7 +2794,9 @@ class TestDockerDaemon(_CheckTestBase):
 
     def test_dirty_version(self, capsys):
         """Test success with a dirty version number."""
-        success, output = self.perform_check(capsys, cmd_effects='"20.1+azure"')
+        success, output = self.perform_check(
+            capsys, cmd_effects='"20.1+azure"'
+        )
         assert output == "PASS -- Docker daemon (running, version 20.1)\n"
         assert success
 


### PR DESCRIPTION
### Summary

Seen example 'docker version' output containing "20.10.24+azure-1" (on GH actions ubuntu-latest runner). We should handle this case of the version being 'dirty' (with "+" followed by other stuff).


### Checklist

<!-- See CONTRIBUTING.md. -->

- [x] Changelog update not required
  <!-- Is there any reason a user might care about the change?
       Have you changed any files that go in the release tarball?
       New GH release must be created after merging if new version added to the changelog. 
  -->
- [x] Static analysis and tests passing
   - Use `commit-check` script, or check GitHub Actions status.
