### PR TITLE
Add kernel modules parameters check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 7.9.1.
 
+### v1.1.11 (2023-06-23)
+
+- Add a check in `host-check` to verify the default kernel modules parameters are being used.
+
 ### v1.1.10 (2023-05-30)
 
 - Add a new 'error' check state to `host-check` for when checks fail to run and update the output message at the bottom of the script, inline with this change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 7.9.1.
 
 ### v1.1.11 (2023-06-23)
 
-- Add a check in `host-check` to verify the default kernel modules parameters are being used.
+- Add a check in `host-check` to verify the correct kernel modules parameters are being used.
 
 ### v1.1.10 (2023-05-30)
 

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -97,12 +97,12 @@ DOUBLE_DASHED_LINE = "==========================================================
 # Kernel parameter values which XRd expects and has been tested with.
 MODULE_EXPECTED_PARAMS = {
     "vfio-pci": {
-        "nointxmask": "N",
-        "disable_idle_d3": "N",
-        "enable_sriov": "N",
+        "nointxmask": {"N"},
+        "disable_idle_d3": {"N"},
+        "enable_sriov": {"N"},
     },
     "igb_uio": {
-        "intr_mode": "msix",
+        "intr_mode": {"msix", "(null)"},
     },
 }
 
@@ -1182,7 +1182,7 @@ def check_shmem_pages_max_size() -> CheckFuncReturn:
 
 
 def _module_params_compare(
-    module: str, exp_param_vals: Dict[str, str]
+    module: str, exp_param_vals: Dict[str, Set[str]]
 ) -> Dict[str, Optional[str]]:
     """
     For a kernel module, check if the runtime parameters have the expected
@@ -1222,7 +1222,7 @@ def _module_params_compare(
                 param_val = f.read().strip()
             # (null) implies the parameter isn't set, and is thus the
             # default value
-            if param_val not in (exp_val, "(null)"):
+            if param_val not in exp_val:
                 param_unexpected[param] = param_val
         except FileNotFoundError:
             param_unexpected[param] = None
@@ -1243,7 +1243,7 @@ def check_modules_expected_params() -> CheckFuncReturn:
             if param_val is not None:
                 module_str += (
                     f"\nThe expected value for parameter {param} is "
-                    f"{param_defaults[param]}, but it is set to {param_val}"
+                    f"{'/'.join(param_defaults[param])}, but it is set to {param_val}"
                 )
             else:
                 module_str += f"\nFailed to check value for parameter: {param}"
@@ -1252,7 +1252,7 @@ def check_modules_expected_params() -> CheckFuncReturn:
             all_modules_str += f"\nFor kernel module: {module}{module_str}"
     if all_modules_str:
         return (
-            CheckState.NEUTRAL,
+            CheckState.WARNING,
             "XRd has not been tested with these kernel module parameters."
             + all_modules_str,
         )

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1212,7 +1212,7 @@ def check_module_non_default_params() -> CheckFuncReturn:
                     param_val = f.read().strip()
                 # (null) implies the parameter isn't set, and is thus the
                 # default value
-                if param_val != def_val and param_val != "(null)":
+                if param_val not in (def_val, "(null)"):
                     param_non_default.append((param, def_val, param_val))
             except FileNotFoundError:
                 param_check_fail.append(param)

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -94,6 +94,18 @@ REQUIRED_CGROUP_MOUNTS = ["systemd", "memory", "pids", "cpu", "cpuset"]
 DASHED_LINE = "----------------------------------------------------------------------------"
 DOUBLE_DASHED_LINE = "============================================================================"
 
+# Default values of runtime parameters of kernel modules
+MODULE_DEFAULT_PARAM = {
+    "vfio-pci": {
+        "nointxmask": "N",
+        "disable_idle_d3": "N",
+        "enable_sriov": "N",
+    },
+    "igb_uio": {
+        "intr_mode": "msix",
+    },
+}
+
 # -----------------------------------------------------------------------------
 # Colours
 # -----------------------------------------------------------------------------
@@ -1169,6 +1181,68 @@ def check_shmem_pages_max_size() -> CheckFuncReturn:
     return CheckState.SUCCESS, f"{shared_mem_max_page_size:.1f} GiB"
 
 
+def check_module_non_default_params() -> CheckFuncReturn:
+    """
+    Checks the kernel modules have been loaded with default runtime parameters
+    (Checks parameters in MODULE_DEFAULT_PARAM)
+    """
+    all_modules_str = ""
+    for module, param_defaults in MODULE_DEFAULT_PARAM.items():
+        module_str = ""
+        if not _is_module_loaded(
+            module.replace("-", "_")
+        ) and not _is_module_builtin(module):
+            # Skip module param check if module is not loaded
+            continue
+        # sysfs filesystem requires the underscore version of the kernel module
+        # name
+        module = module.replace("-", "_")
+        all_params_str, _ = run_cmd(["modinfo", "--field", "parm", module])
+        param_non_default = []
+        param_check_fail = []
+        for param, def_val in param_defaults.items():
+            if not re.search(rf"^{param}:", all_params_str, re.MULTILINE):
+                # if 'param' is absent in modinfo output, it means either the
+                # parameter was introduced in a later kernel version, or the
+                # specific linux distribution does not support the parameter.
+                continue
+            try:
+                path = f"/sys/module/{module}/parameters/{param}"
+                with open(path, "r", encoding="utf-8") as f:
+                    param_val = f.read().strip()
+                # (null) implies the parameter isn't set, and is thus the
+                # default value
+                if param_val != def_val and param_val != "(null)":
+                    param_non_default.append((param, def_val, param_val))
+            except FileNotFoundError:
+                param_check_fail.append(param)
+
+        for param, def_val, param_val in param_non_default:
+            module_str += (
+                f"\nThe default value for parameter {param} is {def_val},"
+                f" but it is set to {param_val}"
+            )
+        if param_check_fail:
+            module_str += (
+                "\nFailed to check paramter value for parameter(s): "
+                + ", ".join(param_check_fail)
+                + "\nUser likely has insufficient permission"
+            )
+        if module_str:
+            all_modules_str += f"\nFor kernel module: {module}{module_str}"
+    if all_modules_str:
+        return (
+            CheckState.NEUTRAL,
+            "XRd has only been tested with default kernel module parameters."
+            + all_modules_str,
+        )
+    else:
+        return (
+            CheckState.SUCCESS,
+            "Kernel modules loaded with default parameters.",
+        )
+
+
 # -------------------------------------
 # Docker checks
 # -------------------------------------
@@ -1384,6 +1458,7 @@ BASE_CHECKS = [
     Check("Core pattern", check_core_pattern, []),
     Check("ASLR", check_userspace_aslr, []),
     Check("Linux Security Modules", check_linux_security_modules, []),
+    Check("Kernel module parameters", check_module_non_default_params, []),
 ]
 
 CONTROL_PLANE_CHECKS = [

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -97,12 +97,12 @@ DOUBLE_DASHED_LINE = "==========================================================
 # Kernel parameter values which XRd expects and has been tested with.
 MODULE_EXPECTED_PARAMS = {
     "vfio-pci": {
-        "nointxmask": {"N"},
-        "disable_idle_d3": {"N"},
-        "enable_sriov": {"N"},
+        "nointxmask": ["N"],
+        "disable_idle_d3": ["N"],
+        "enable_sriov": ["N"],
     },
     "igb_uio": {
-        "intr_mode": {"msix", "(null)"},
+        "intr_mode": ["msix", "(null)"],
     },
 }
 
@@ -1182,7 +1182,7 @@ def check_shmem_pages_max_size() -> CheckFuncReturn:
 
 
 def _module_params_compare(
-    module: str, exp_param_vals: Dict[str, Set[str]]
+    module: str, exp_param_vals: Dict[str, List[str]]
 ) -> Dict[str, Optional[str]]:
     """
     For a kernel module, check if the runtime parameters have the expected

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1181,6 +1181,54 @@ def check_shmem_pages_max_size() -> CheckFuncReturn:
     return CheckState.SUCCESS, f"{shared_mem_max_page_size:.1f} GiB"
 
 
+def _check_module_param(
+    module: str, exp_param_vals: Dict[str, str]
+) -> Tuple[Dict[str, str], List[str]]:
+    """
+    For a kernel module, check if the runtime parameters have the expected
+    values.
+
+    :param module:
+        Name of the module
+
+    :param exp_param_vals:
+        Dictionary mapping parameter name to the expected value of the parameter
+
+    :return:
+        param_unexpected: A dict containing parameters with unexpected values
+        param_check_fail: List of parameters failed to check
+    """
+    if not _is_module_loaded(
+        module.replace("-", "_")
+    ) and not _is_module_builtin(module):
+        # Skip module param check if module is not loaded
+        return {}, []
+    # sysfs filesystem requires the underscore version of the kernel module
+    # name
+    module = module.replace("-", "_")
+    all_params_str, _ = run_cmd(["modinfo", "--field", "parm", module])
+    param_unexpected = {}
+    param_check_fail = []
+    for param, exp_val in exp_param_vals.items():
+        if not re.search(rf"^{param}:", all_params_str, re.MULTILINE):
+            # if 'param' is absent in modinfo output, it means either the
+            # parameter was introduced in a later kernel version, or the
+            # specific linux distribution does not support the parameter.
+            continue
+        try:
+            path = f"/sys/module/{module}/parameters/{param}"
+            with open(path, "r", encoding="utf-8") as f:
+                param_val = f.read().strip()
+            # (null) implies the parameter isn't set, and is thus the
+            # default value
+            if param_val not in (exp_val, "(null)"):
+                param_unexpected[param] = param_val
+        except FileNotFoundError:
+            param_check_fail.append(param)
+
+    return param_unexpected, param_check_fail
+
+
 def check_module_non_default_params() -> CheckFuncReturn:
     """
     Checks the kernel modules have been loaded with default runtime parameters
@@ -1189,38 +1237,14 @@ def check_module_non_default_params() -> CheckFuncReturn:
     all_modules_str = ""
     for module, param_defaults in MODULE_DEFAULT_PARAM.items():
         module_str = ""
-        if not _is_module_loaded(
-            module.replace("-", "_")
-        ) and not _is_module_builtin(module):
-            # Skip module param check if module is not loaded
-            continue
-        # sysfs filesystem requires the underscore version of the kernel module
-        # name
-        module = module.replace("-", "_")
-        all_params_str, _ = run_cmd(["modinfo", "--field", "parm", module])
-        param_non_default = []
-        param_check_fail = []
-        for param, def_val in param_defaults.items():
-            if not re.search(rf"^{param}:", all_params_str, re.MULTILINE):
-                # if 'param' is absent in modinfo output, it means either the
-                # parameter was introduced in a later kernel version, or the
-                # specific linux distribution does not support the parameter.
-                continue
-            try:
-                path = f"/sys/module/{module}/parameters/{param}"
-                with open(path, "r", encoding="utf-8") as f:
-                    param_val = f.read().strip()
-                # (null) implies the parameter isn't set, and is thus the
-                # default value
-                if param_val not in (def_val, "(null)"):
-                    param_non_default.append((param, def_val, param_val))
-            except FileNotFoundError:
-                param_check_fail.append(param)
 
-        for param, def_val, param_val in param_non_default:
+        param_non_default, param_check_fail = _check_module_param(
+            module, param_defaults
+        )
+        for param, param_val in param_non_default.items():
             module_str += (
-                f"\nThe default value for parameter {param} is {def_val},"
-                f" but it is set to {param_val}"
+                f"\nThe default value for parameter {param} is "
+                f" {param_defaults[param]}, but it is set to {param_val}"
             )
         if param_check_fail:
             module_str += (

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1183,7 +1183,7 @@ def check_shmem_pages_max_size() -> CheckFuncReturn:
 
 def _check_module_param(
     module: str, exp_param_vals: Dict[str, str]
-) -> Tuple[Dict[str, str], List[str]]:
+) -> Dict[str, Optional[str]]:
     """
     For a kernel module, check if the runtime parameters have the expected
     values.
@@ -1195,20 +1195,21 @@ def _check_module_param(
         Dictionary mapping parameter name to the expected value of the parameter
 
     :return:
-        param_unexpected: A dict containing parameters with unexpected values
-        param_check_fail: List of parameters failed to check
+        A dict containing parameters with unexpected values
+        If failed to check value for a parameter, returns None as the dict
+        value for the parameter
     """
+    param_unexpected = {}
+
     if not _is_module_loaded(
         module.replace("-", "_")
     ) and not _is_module_builtin(module):
         # Skip module param check if module is not loaded
-        return {}, []
+        return param_unexpected
     # sysfs filesystem requires the underscore version of the kernel module
     # name
     module = module.replace("-", "_")
     all_params_str, _ = run_cmd(["modinfo", "--field", "parm", module])
-    param_unexpected = {}
-    param_check_fail = []
     for param, exp_val in exp_param_vals.items():
         if not re.search(rf"^{param}:", all_params_str, re.MULTILINE):
             # if 'param' is absent in modinfo output, it means either the
@@ -1224,9 +1225,9 @@ def _check_module_param(
             if param_val not in (exp_val, "(null)"):
                 param_unexpected[param] = param_val
         except FileNotFoundError:
-            param_check_fail.append(param)
+            param_unexpected[param] = None
 
-    return param_unexpected, param_check_fail
+    return param_unexpected
 
 
 def check_module_non_default_params() -> CheckFuncReturn:
@@ -1237,21 +1238,15 @@ def check_module_non_default_params() -> CheckFuncReturn:
     all_modules_str = ""
     for module, param_defaults in MODULE_DEFAULT_PARAM.items():
         module_str = ""
-
-        param_non_default, param_check_fail = _check_module_param(
-            module, param_defaults
-        )
+        param_non_default = _check_module_param(module, param_defaults)
         for param, param_val in param_non_default.items():
-            module_str += (
-                f"\nThe default value for parameter {param} is "
-                f"{param_defaults[param]}, but it is set to {param_val}"
-            )
-        if param_check_fail:
-            module_str += (
-                "\nFailed to check paramter value for parameter(s): "
-                + ", ".join(param_check_fail)
-                + "\nUser likely has insufficient permission"
-            )
+            if param_val is not None:
+                module_str += (
+                    f"\nThe default value for parameter {param} is "
+                    f"{param_defaults[param]}, but it is set to {param_val}"
+                )
+            else:
+                module_str += f"\nFailed to check value for parameter: {param}"
         if module_str:
             all_modules_str += f"\nFor kernel module: {module}{module_str}"
     if all_modules_str:

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1199,7 +1199,7 @@ def _check_module_param(
         If failed to check value for a parameter, returns None as the dict
         value for the parameter
     """
-    param_unexpected = {}
+    param_unexpected: Dict[str, Optional[str]] = {}
 
     if not _is_module_loaded(
         module.replace("-", "_")

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1244,7 +1244,7 @@ def check_module_non_default_params() -> CheckFuncReturn:
         for param, param_val in param_non_default.items():
             module_str += (
                 f"\nThe default value for parameter {param} is "
-                f" {param_defaults[param]}, but it is set to {param_val}"
+                f"{param_defaults[param]}, but it is set to {param_val}"
             )
         if param_check_fail:
             module_str += (

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -95,6 +95,7 @@ DASHED_LINE = "-----------------------------------------------------------------
 DOUBLE_DASHED_LINE = "============================================================================"
 
 # Default values of runtime parameters of kernel modules
+# Kernel parameter values which XRd expects and has been tested with.
 MODULE_DEFAULT_PARAM = {
     "vfio-pci": {
         "nointxmask": "N",
@@ -1181,7 +1182,7 @@ def check_shmem_pages_max_size() -> CheckFuncReturn:
     return CheckState.SUCCESS, f"{shared_mem_max_page_size:.1f} GiB"
 
 
-def _check_module_param(
+def _module_param_compare(
     module: str, exp_param_vals: Dict[str, str]
 ) -> Dict[str, Optional[str]]:
     """
@@ -1234,11 +1235,13 @@ def check_module_non_default_params() -> CheckFuncReturn:
     """
     Checks the kernel modules have been loaded with default runtime parameters
     (Checks parameters in MODULE_DEFAULT_PARAM)
+    XRd only uses default parameters, and that this check would need to change
+    if XRd required a non-default parameter to be set.
     """
     all_modules_str = ""
     for module, param_defaults in MODULE_DEFAULT_PARAM.items():
         module_str = ""
-        param_non_default = _check_module_param(module, param_defaults)
+        param_non_default = _module_param_compare(module, param_defaults)
         for param, param_val in param_non_default.items():
             if param_val is not None:
                 module_str += (
@@ -1248,6 +1251,7 @@ def check_module_non_default_params() -> CheckFuncReturn:
             else:
                 module_str += f"\nFailed to check value for parameter: {param}"
         if module_str:
+            module_str = textwrap.indent(module_str, "   ")
             all_modules_str += f"\nFor kernel module: {module}{module_str}"
     if all_modules_str:
         return (

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -94,9 +94,8 @@ REQUIRED_CGROUP_MOUNTS = ["systemd", "memory", "pids", "cpu", "cpuset"]
 DASHED_LINE = "----------------------------------------------------------------------------"
 DOUBLE_DASHED_LINE = "============================================================================"
 
-# Default values of runtime parameters of kernel modules
 # Kernel parameter values which XRd expects and has been tested with.
-MODULE_DEFAULT_PARAM = {
+MODULE_EXPECTED_PARAMS = {
     "vfio-pci": {
         "nointxmask": "N",
         "disable_idle_d3": "N",
@@ -1182,7 +1181,7 @@ def check_shmem_pages_max_size() -> CheckFuncReturn:
     return CheckState.SUCCESS, f"{shared_mem_max_page_size:.1f} GiB"
 
 
-def _module_param_compare(
+def _module_params_compare(
     module: str, exp_param_vals: Dict[str, str]
 ) -> Dict[str, Optional[str]]:
     """
@@ -1231,21 +1230,19 @@ def _module_param_compare(
     return param_unexpected
 
 
-def check_module_non_default_params() -> CheckFuncReturn:
+def check_modules_expected_params() -> CheckFuncReturn:
     """
-    Checks the kernel modules have been loaded with default runtime parameters
-    (Checks parameters in MODULE_DEFAULT_PARAM)
-    XRd only uses default parameters, and that this check would need to change
-    if XRd required a non-default parameter to be set.
+    Checks the kernel modules have been loaded with expected runtime parameters
+    (Checks parameters in MODULE_EXPECTED_PARAMS)
     """
     all_modules_str = ""
-    for module, param_defaults in MODULE_DEFAULT_PARAM.items():
+    for module, param_defaults in MODULE_EXPECTED_PARAMS.items():
         module_str = ""
-        param_non_default = _module_param_compare(module, param_defaults)
+        param_non_default = _module_params_compare(module, param_defaults)
         for param, param_val in param_non_default.items():
             if param_val is not None:
                 module_str += (
-                    f"\nThe default value for parameter {param} is "
+                    f"\nThe expected value for parameter {param} is "
                     f"{param_defaults[param]}, but it is set to {param_val}"
                 )
             else:
@@ -1256,13 +1253,13 @@ def check_module_non_default_params() -> CheckFuncReturn:
     if all_modules_str:
         return (
             CheckState.NEUTRAL,
-            "XRd has only been tested with default kernel module parameters."
+            "XRd has not been tested with these kernel module parameters."
             + all_modules_str,
         )
     else:
         return (
             CheckState.SUCCESS,
-            "Kernel modules loaded with default parameters.",
+            "Kernel modules loaded with expected parameters.",
         )
 
 
@@ -1481,7 +1478,7 @@ BASE_CHECKS = [
     Check("Core pattern", check_core_pattern, []),
     Check("ASLR", check_userspace_aslr, []),
     Check("Linux Security Modules", check_linux_security_modules, []),
-    Check("Kernel module parameters", check_module_non_default_params, []),
+    Check("Kernel module parameters", check_modules_expected_params, []),
 ]
 
 CONTROL_PLANE_CHECKS = [

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1220,8 +1220,6 @@ def _module_params_compare(
             path = f"/sys/module/{module}/parameters/{param}"
             with open(path, "r", encoding="utf-8") as f:
                 param_val = f.read().strip()
-            # (null) implies the parameter isn't set, and is thus the
-            # default value
             if param_val not in exp_val:
                 param_unexpected[param] = param_val
         except FileNotFoundError:

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -2047,7 +2047,7 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
             INFO -- Kernel module parameters
                     XRd has only been tested with default kernel module parameters.
                     For kernel module: vfio-pci
-                    The default value for parameter disable_idle_d3 is N, but it is set to Y
+                       The default value for parameter disable_idle_d3 is N, but it is set to Y
             """
         )
         assert result is CheckState.NEUTRAL
@@ -2071,9 +2071,9 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
             INFO -- Kernel module parameters
                     XRd has only been tested with default kernel module parameters.
                     For kernel module: vfio-pci
-                    The default value for parameter disable_idle_d3 is N, but it is set to Y
+                       The default value for parameter disable_idle_d3 is N, but it is set to Y
                     For kernel module: igb_uio
-                    The default value for parameter intr_mode is msix, but it is set to legacy
+                       The default value for parameter intr_mode is msix, but it is set to legacy
             """
         )
         assert result is CheckState.NEUTRAL
@@ -2141,7 +2141,7 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
             INFO -- Kernel module parameters
                     XRd has only been tested with default kernel module parameters.
                     For kernel module: igb_uio
-                    Failed to check value for parameter: intr_mode
+                       Failed to check value for parameter: intr_mode
             """
         )
         assert result is CheckState.NEUTRAL

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -2147,7 +2147,7 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
         assert result is CheckState.WARNING
 
     def test_parm_null_value(self, capsys):
-        """Test one parameter having (null) value"""
+        """Test intr_mode parameter having (null) value"""
         cmd_outputs = [
             "",
             None,

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -60,7 +60,7 @@ def perform_check(
     name: str,
     *,
     cmds: Optional[Union[Tuple[str, Any], List[Tuple[str, Any]]]] = None,
-    files: Optional[Union[Tuple[str, str], List[Tuple[str, str]]]] = None,
+    files: Optional[Union[Tuple[str, Any], List[Tuple[str, Any]]]] = None,
     deps: Optional[List[str]] = None,
     failed_deps: Optional[List[str]] = None,
 ) -> Tuple[CheckState, str]:
@@ -142,7 +142,8 @@ def perform_check(
                     effects.append(
                         mock.mock_open(read_data=effect).return_value
                     )
-                else:
+                # Skip file if effect is None
+                elif effect is not None:
                     effects.append(effect)
             mock_open = ctxs.enter_context(
                 mock.patch("builtins.open", side_effect=effects)
@@ -166,7 +167,8 @@ def perform_check(
     # Check the expected files were read.
     if files:
         actual_files = [call[0][0] for call in mock_open.call_args_list]
-        assert [f for f, _ in files] == actual_files
+        # Only expect the "not None" files to be read.
+        assert [f for f, e in files if e is not None] == actual_files
 
     output = capsys.readouterr().out
     if deps:
@@ -1928,6 +1930,243 @@ class TestUDPParameters(_CheckTestBase):
             """
         )
         assert result is CheckState.ERROR
+
+
+class TestKernelModuleParameters(_CheckTestBase):
+
+    check_group = "base"
+    check_name = "Kernel module parameters"
+    files = [
+        "/sys/module/vfio_pci/parameters/nointxmask",
+        "/sys/module/vfio_pci/parameters/disable_idle_d3",
+        "/sys/module/vfio_pci/parameters/enable_sriov",
+        "/sys/module/igb_uio/parameters/intr_mode",
+    ]
+    cmds = [
+        "lsmod | grep -q '^vfio_pci '",  # loaded
+        "grep -q /vfio-pci.ko /lib/modules/*/modules.builtin",  # builtin
+        "modinfo --field parm vfio_pci",
+        "lsmod | grep -q '^igb_uio '",  # loaded
+        "grep -q /igb_uio.ko /lib/modules/*/modules.builtin",  # builtin
+        "modinfo --field parm igb_uio",
+    ]
+    # Output of 'modinfo --field parm vfio_pci' with all parameters enabled
+    vfio_pci_parms = """\
+ids:Initial PCI IDs to add to the vfio driver, format is "vendor:device...
+nointxmask:Disable support for PCI 2.3 style INTx masking.  If this ...
+disable_idle_d3:Disable using the PCI D3 low power state for ...
+enable_sriov:Enable support for SR-IOV configuration.  Enabling S...
+disable_denylist:Disable use of device denylist. Disabling the deny...
+        """
+    # Output of 'modinfo --field parm igb_uio' with all parameters enabled
+    igb_uio_parms = """\
+intr_mode:igb_uio interrupt mode (default=msix):
+    msix       Use MSIX interrupt
+    msi        Use MSI interrupt
+    legacy     Use Legacy interrupt
+
+ (charp)
+wc_activate:Activate support for write combining (WC) (default=0)
+    0 - disable
+    other - enable
+ (int)
+        """
+
+    def test_success(self, capsys):
+        """
+        Test the success case.
+        Both modules loaded and all parameters supported and enabled with
+        default values
+        """
+
+        cmd_outputs = [
+            "",
+            None,
+            self.vfio_pci_parms,
+            "",
+            None,
+            self.igb_uio_parms,
+        ]
+        files_content = ["N", "N", "N", "msix"]
+        result, output = self.perform_check(
+            capsys, cmd_effects=cmd_outputs, read_effects=files_content
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            """\
+            PASS -- Kernel module parameters
+                    Kernel modules loaded with default parameters.
+            """
+        )
+        assert result is CheckState.SUCCESS
+
+    def test_one_parm_disable(self, capsys):
+        """Test one parameter not supported by the kernel."""
+        vfio_pci_test_parm = """\
+ids:Initial PCI IDs to add to the vfio driver, format is "vendor:device...
+nointxmask:Disable support for PCI 2.3 style INTx masking.  If this ...
+disable_idle_d3:Disable using the PCI D3 low power state for ...
+disable_denylist:Disable use of device denylist. Disabling the deny...
+        """
+        cmd_outputs = [
+            "",
+            None,
+            vfio_pci_test_parm,
+            "",
+            None,
+            self.igb_uio_parms,
+        ]
+        files_content = ["N", "N", None, "msix"]
+        result, output = self.perform_check(
+            capsys, cmd_effects=cmd_outputs, read_effects=files_content
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            """\
+            PASS -- Kernel module parameters
+                    Kernel modules loaded with default parameters.
+            """
+        )
+        assert result is CheckState.SUCCESS
+
+    def test_one_parm_non_default(self, capsys):
+        """Test one parameter having a non-default value."""
+        cmd_outputs = [
+            "",
+            None,
+            self.vfio_pci_parms,
+            "",
+            None,
+            self.igb_uio_parms,
+        ]
+        files_content = ["N", "Y", "N", "msix"]
+        result, output = self.perform_check(
+            capsys, cmd_effects=cmd_outputs, read_effects=files_content
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            """\
+            INFO -- Kernel module parameters
+                    XRd has only been tested with default kernel module parameters.
+                    For kernel module: vfio_pci
+                    The default value for parameter disable_idle_d3 is N, but it is set to Y
+            """
+        )
+        assert result is CheckState.NEUTRAL
+
+    def test_two_parm_non_default(self, capsys):
+        """Test two parameters having non-default values."""
+        cmd_outputs = [
+            "",
+            None,
+            self.vfio_pci_parms,
+            "",
+            None,
+            self.igb_uio_parms,
+        ]
+        files_content = ["N", "Y", "N", "legacy"]
+        result, output = self.perform_check(
+            capsys, cmd_effects=cmd_outputs, read_effects=files_content
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            """\
+            INFO -- Kernel module parameters
+                    XRd has only been tested with default kernel module parameters.
+                    For kernel module: vfio_pci
+                    The default value for parameter disable_idle_d3 is N, but it is set to Y
+                    For kernel module: igb_uio
+                    The default value for parameter intr_mode is msix, but it is set to legacy
+            """
+        )
+        assert result is CheckState.NEUTRAL
+
+    def test_one_module_not_loaded(self, capsys):
+        """Test where one module is not loaded."""
+        cmd_outputs = [
+            subprocess.SubprocessError(1, ""),
+            subprocess.SubprocessError(1, ""),
+            None,
+            "",
+            None,
+            self.igb_uio_parms,
+        ]
+        files_content = [None, None, None, "msix"]
+        result, output = self.perform_check(
+            capsys, cmd_effects=cmd_outputs, read_effects=files_content
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            """\
+            PASS -- Kernel module parameters
+                    Kernel modules loaded with default parameters.
+            """
+        )
+        assert result is CheckState.SUCCESS
+
+    def test_both_module_not_loaded(self, capsys):
+        """Test where both modules are not loaded."""
+        cmd_outputs = [
+            subprocess.SubprocessError(1, ""),
+            subprocess.SubprocessError(1, ""),
+            None,
+            subprocess.SubprocessError(1, ""),
+            subprocess.SubprocessError(1, ""),
+            None,
+        ]
+        files_content = [None, None, None, None]
+        result, output = self.perform_check(
+            capsys, cmd_effects=cmd_outputs, read_effects=files_content
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            """\
+            PASS -- Kernel module parameters
+                    Kernel modules loaded with default parameters.
+            """
+        )
+        assert result is CheckState.SUCCESS
+
+    def test_parm_file_not_found(self, capsys):
+        """Test one parameter file not being found"""
+        cmd_outputs = [
+            "",
+            None,
+            self.vfio_pci_parms,
+            "",
+            None,
+            self.igb_uio_parms,
+        ]
+        files_content = ["N", "N", "N", FileNotFoundError]
+        result, output = self.perform_check(
+            capsys, cmd_effects=cmd_outputs, read_effects=files_content
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            """\
+            INFO -- Kernel module parameters
+                    XRd has only been tested with default kernel module parameters.
+                    For kernel module: igb_uio
+                    Failed to check paramter value for parameter(s): intr_mode
+                    User likely has insufficient permission
+            """
+        )
+        assert result is CheckState.NEUTRAL
+
+    def test_parm_null_value(self, capsys):
+        """Test one parameter having (null) value"""
+        cmd_outputs = [
+            "",
+            None,
+            self.vfio_pci_parms,
+            "",
+            None,
+            self.igb_uio_parms,
+        ]
+        files_content = ["N", "N", "N", "(null)"]
+        result, output = self.perform_check(
+            capsys, cmd_effects=cmd_outputs, read_effects=files_content
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            """\
+            PASS -- Kernel module parameters
+                    Kernel modules loaded with default parameters.
+            """
+        )
+        assert result is CheckState.SUCCESS
 
 
 # -------------------------------------

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -2141,8 +2141,7 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
             INFO -- Kernel module parameters
                     XRd has only been tested with default kernel module parameters.
                     For kernel module: igb_uio
-                    Failed to check paramter value for parameter(s): intr_mode
-                    User likely has insufficient permission
+                    Failed to check value for parameter: intr_mode
             """
         )
         assert result is CheckState.NEUTRAL

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -1995,7 +1995,7 @@ wc_activate:Activate support for write combining (WC) (default=0)
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             PASS -- Kernel module parameters
-                    Kernel modules loaded with default parameters.
+                    Kernel modules loaded with expected parameters.
             """
         )
         assert result is CheckState.SUCCESS
@@ -2023,7 +2023,7 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             PASS -- Kernel module parameters
-                    Kernel modules loaded with default parameters.
+                    Kernel modules loaded with expected parameters.
             """
         )
         assert result is CheckState.SUCCESS
@@ -2045,9 +2045,9 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             INFO -- Kernel module parameters
-                    XRd has only been tested with default kernel module parameters.
+                    XRd has not been tested with these kernel module parameters.
                     For kernel module: vfio-pci
-                       The default value for parameter disable_idle_d3 is N, but it is set to Y
+                       The expected value for parameter disable_idle_d3 is N, but it is set to Y
             """
         )
         assert result is CheckState.NEUTRAL
@@ -2069,11 +2069,11 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             INFO -- Kernel module parameters
-                    XRd has only been tested with default kernel module parameters.
+                    XRd has not been tested with these kernel module parameters.
                     For kernel module: vfio-pci
-                       The default value for parameter disable_idle_d3 is N, but it is set to Y
+                       The expected value for parameter disable_idle_d3 is N, but it is set to Y
                     For kernel module: igb_uio
-                       The default value for parameter intr_mode is msix, but it is set to legacy
+                       The expected value for parameter intr_mode is msix, but it is set to legacy
             """
         )
         assert result is CheckState.NEUTRAL
@@ -2095,7 +2095,7 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             PASS -- Kernel module parameters
-                    Kernel modules loaded with default parameters.
+                    Kernel modules loaded with expected parameters.
             """
         )
         assert result is CheckState.SUCCESS
@@ -2117,7 +2117,7 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             PASS -- Kernel module parameters
-                    Kernel modules loaded with default parameters.
+                    Kernel modules loaded with expected parameters.
             """
         )
         assert result is CheckState.SUCCESS
@@ -2139,7 +2139,7 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             INFO -- Kernel module parameters
-                    XRd has only been tested with default kernel module parameters.
+                    XRd has not been tested with these kernel module parameters.
                     For kernel module: igb_uio
                        Failed to check value for parameter: intr_mode
             """
@@ -2163,7 +2163,7 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             PASS -- Kernel module parameters
-                    Kernel modules loaded with default parameters.
+                    Kernel modules loaded with expected parameters.
             """
         )
         assert result is CheckState.SUCCESS

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -1933,6 +1933,7 @@ class TestUDPParameters(_CheckTestBase):
 
 
 class TestKernelModuleParameters(_CheckTestBase):
+    """Tests for default Kernel Parameters check."""
 
     check_group = "base"
     check_name = "Kernel module parameters"

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -2044,13 +2044,13 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-            INFO -- Kernel module parameters
+            WARN -- Kernel module parameters
                     XRd has not been tested with these kernel module parameters.
                     For kernel module: vfio-pci
                        The expected value for parameter disable_idle_d3 is N, but it is set to Y
             """
         )
-        assert result is CheckState.NEUTRAL
+        assert result is CheckState.WARNING
 
     def test_two_parm_non_default(self, capsys):
         """Test two parameters having non-default values."""
@@ -2068,15 +2068,15 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-            INFO -- Kernel module parameters
+            WARN -- Kernel module parameters
                     XRd has not been tested with these kernel module parameters.
                     For kernel module: vfio-pci
                        The expected value for parameter disable_idle_d3 is N, but it is set to Y
                     For kernel module: igb_uio
-                       The expected value for parameter intr_mode is msix, but it is set to legacy
+                       The expected value for parameter intr_mode is msix/(null), but it is set to legacy
             """
         )
-        assert result is CheckState.NEUTRAL
+        assert result is CheckState.WARNING
 
     def test_one_module_not_loaded(self, capsys):
         """Test where one module is not loaded."""
@@ -2138,13 +2138,13 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-            INFO -- Kernel module parameters
+            WARN -- Kernel module parameters
                     XRd has not been tested with these kernel module parameters.
                     For kernel module: igb_uio
                        Failed to check value for parameter: intr_mode
             """
         )
-        assert result is CheckState.NEUTRAL
+        assert result is CheckState.WARNING
 
     def test_parm_null_value(self, capsys):
         """Test one parameter having (null) value"""

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -2046,7 +2046,7 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
             """\
             INFO -- Kernel module parameters
                     XRd has only been tested with default kernel module parameters.
-                    For kernel module: vfio_pci
+                    For kernel module: vfio-pci
                     The default value for parameter disable_idle_d3 is N, but it is set to Y
             """
         )
@@ -2070,7 +2070,7 @@ disable_denylist:Disable use of device denylist. Disabling the deny...
             """\
             INFO -- Kernel module parameters
                     XRd has only been tested with default kernel module parameters.
-                    For kernel module: vfio_pci
+                    For kernel module: vfio-pci
                     The default value for parameter disable_idle_d3 is N, but it is set to Y
                     For kernel module: igb_uio
                     The default value for parameter intr_mode is msix, but it is set to legacy


### PR DESCRIPTION
### Summary

- Add check in the `host-check` script to verify the kernel modules have been loaded with default runtime parameters.
- In `test_host_check`:
   - Add tests to check different configs
   - In `perform_check`, if `None` is passed as the file content, then except the file to be read (same as `cmd_effects`)

### Checklist

<!-- See CONTRIBUTING.md. -->

- [x] Changelog updated (or not required)
  <!-- Is there any reason a user might care about the change?
       Have you changed any files that go in the release tarball?
       New GH release must be created after merging if new version added to the changelog. 
  -->
- [x] Static analysis and tests passing
   - Use `commit-check` script, or check GitHub Actions status.
