### PR TITLE
Docker compose v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 7.9.1.
 
+### v1.1.12 (2023-06-30)
+
+- Add Docker Compose v2 support to `host-check` and `xr-compose` scripts.
+
 ### v1.1.11 (2023-06-23)
 
 - Add a check in `host-check` to verify the correct kernel modules parameters are being used.

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1364,21 +1364,27 @@ def check_supports_d_type() -> CheckFuncReturn:
 
 def check_docker_compose() -> CheckFuncReturn:
     """Check that the docker-compose version is 1.18.x or higher."""
-    cmd = "docker-compose --version"
-    try:
-        # Use a longer than default timeout as this command has been known to
-        # time out.
-        version_str = run_cmd(shlex.split(cmd), timeout=10)[0].strip()
-    except (FileNotFoundError, subprocess.SubprocessError):
+    plugin_cmd = "docker compose version"
+    standalone_cmd = "docker-compose --version"
+    for cmd in (plugin_cmd, standalone_cmd):
+        try:
+            # Use a longer than default timeout as this command has been known to
+            # time out.
+            version_str = run_cmd(shlex.split(cmd), timeout=10)[0].strip()
+            break
+        except (FileNotFoundError, subprocess.SubprocessError):
+            pass
+    else:
         return (
             CheckState.FAILED,
-            f"Docker Compose not found (checked with {cmd!r}).\n"
+            f"Docker Compose not found (checked with {plugin_cmd!r} and {standalone_cmd!r}).\n"
             f"Launching XRd topologies with xr-compose requires docker-compose.\n"
             f"See installation instructions at https://docs.docker.com/compose/install/.",
         )
 
     version_match = re.match(
-        r"docker-compose version (\d+\.\d+(?:\.\d+)?)", version_str
+        r"(?:docker-compose|Docker Compose) version v?(\d+\.\d+(?:\.\d+)?)",
+        version_str,
     )
     if not version_match:
         return (

--- a/scripts/xr-compose
+++ b/scripts/xr-compose
@@ -958,9 +958,9 @@ class XRCompose:
                     pass
             else:
                 raise Error(
-                    f"Docker Compose not found.\n"
-                    f"Launching XRd topologies with xr-compose requires docker-compose.\n"
-                    f"See installation instructions at https://docs.docker.com/compose/install/.",
+                    "Docker Compose not found.\n"
+                    "Launching XRd topologies with xr-compose requires docker-compose.\n"
+                    "See installation instructions at https://docs.docker.com/compose/install/.",
                 )
         return self._docker_compose_cmd
 

--- a/scripts/xr-compose
+++ b/scripts/xr-compose
@@ -926,6 +926,8 @@ class XRCompose:
 
         self.image = image
 
+        self._docker_compose_cmd: Optional[List[str]] = None
+
         self.check_input_and_output()
 
         # Load the input YAML
@@ -938,6 +940,27 @@ class XRCompose:
         self.networks: List[Network] = []
         self.services: List[Service] = []
         self.errors: List[Exception] = []
+
+    @property
+    def docker_compose_cmd(self) -> List[str]:
+        if self._docker_compose_cmd is None:
+            plugin = (["docker", "compose"], ["version"])
+            standalone = (["docker-compose"], ["--version"])
+            for docker_compose, version_cmd in (plugin, standalone):
+                try:
+                    subprocess.check_output(docker_compose + version_cmd, stderr=subprocess.DEVNULL)
+                    # Cache result if no error is raised
+                    self._docker_compose_cmd = docker_compose
+                    break
+                except (FileNotFoundError, subprocess.SubprocessError):
+                    pass
+            else:
+                raise Error(
+                    f"Docker Compose not found.\n"
+                    f"Launching XRd topologies with xr-compose requires docker-compose.\n"
+                    f"See installation instructions at https://docs.docker.com/compose/install/.",
+                )
+        return self._docker_compose_cmd
 
     # -------------------------------------------------------------------
     # Methods related to checking input arguments
@@ -971,7 +994,7 @@ class XRCompose:
         # is not covered by the python API. Don't include the last empty line.
         try:
             docker_compose_out = subprocess.check_output(
-                ["docker-compose", "-f", self.output_file, "ps"],
+                self.docker_compose_cmd + ["-f", self.output_file, "ps"],
                 universal_newlines=True,
             )
         except subprocess.CalledProcessError:
@@ -1889,7 +1912,7 @@ class XRCompose:
         """
         LOGGER.info("Launching docker-compose topology...")
         subprocess.run(
-            ["docker-compose", "-f", self.output_file, "up", "-d"], check=True
+            self.docker_compose_cmd + ["-f", self.output_file, "up", "-d"], check=True
         )
 
 

--- a/scripts/xr-compose
+++ b/scripts/xr-compose
@@ -948,7 +948,9 @@ class XRCompose:
             standalone = (["docker-compose"], ["--version"])
             for docker_compose, version_cmd in (plugin, standalone):
                 try:
-                    subprocess.check_output(docker_compose + version_cmd, stderr=subprocess.DEVNULL)
+                    subprocess.check_output(
+                        docker_compose + version_cmd, stderr=subprocess.DEVNULL
+                    )
                     # Cache result if no error is raised
                     self._docker_compose_cmd = docker_compose
                     break
@@ -1912,7 +1914,8 @@ class XRCompose:
         """
         LOGGER.info("Launching docker-compose topology...")
         subprocess.run(
-            self.docker_compose_cmd + ["-f", self.output_file, "up", "-d"], check=True
+            self.docker_compose_cmd + ["-f", self.output_file, "up", "-d"],
+            check=True,
         )
 
 

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -3338,12 +3338,24 @@ class TestDockerCompose(_CheckTestBase):
 
     check_group = "xr-compose"
     check_name = "docker-compose"
-    cmds = ["docker-compose --version"]
+    cmds = ["docker compose version", "docker-compose --version"]
 
-    def test_success(self, capsys):
+    def test_success_plugin(self, capsys):
         """Test the success case."""
         result, output = self.perform_check(
-            capsys, cmd_effects="docker-compose version 1.18.0"
+            capsys, cmd_effects="Docker Compose version v2.19.0"
+        )
+        assert (
+            textwrap.dedent(output)
+            == "PASS -- docker-compose (version 2.19.0)\n"
+        )
+        assert result is CheckState.SUCCESS
+
+    def test_success_standalone(self, capsys):
+        """Test the success case."""
+        cmd_effects = [subprocess.SubprocessError, "docker-compose version 1.18.0"]
+        result, output = self.perform_check(
+            capsys, cmd_effects=cmd_effects
         )
         assert (
             textwrap.dedent(output)
@@ -3353,13 +3365,14 @@ class TestDockerCompose(_CheckTestBase):
 
     def test_subproc_error(self, capsys):
         """Test a subprocess error being raised."""
+        cmd_effects = [subprocess.SubprocessError, subprocess.SubprocessError]
         result, output = self.perform_check(
-            capsys, cmd_effects=subprocess.SubprocessError
+            capsys, cmd_effects=cmd_effects
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             FAIL -- docker-compose
-                    Docker Compose not found (checked with 'docker-compose --version').
+                    Docker Compose not found (checked with 'docker compose version' and 'docker-compose --version').
                     Launching XRd topologies with xr-compose requires docker-compose.
                     See installation instructions at https://docs.docker.com/compose/install/.
             """
@@ -3368,8 +3381,9 @@ class TestDockerCompose(_CheckTestBase):
 
     def test_no_version_match(self, capsys):
         """Test failure to match the version in the output."""
+        cmd_effects = ["unexpected output", None]
         result, output = self.perform_check(
-            capsys, cmd_effects="unexpected output"
+            capsys, cmd_effects=cmd_effects
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
@@ -3381,8 +3395,9 @@ class TestDockerCompose(_CheckTestBase):
 
     def test_old_version(self, capsys):
         """Test the version being too old."""
+        cmd_effects = [subprocess.SubprocessError, "docker-compose version 1.17.10"]
         result, output = self.perform_check(
-            capsys, cmd_effects="docker-compose version 1.17.10"
+            capsys, cmd_effects=cmd_effects
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
@@ -3395,8 +3410,9 @@ class TestDockerCompose(_CheckTestBase):
 
     def test_unexpected_error(self, capsys):
         """Test unexpected error being raised."""
+        cmd_effects = [Exception("test exception"), None]
         result, output = self.perform_check(
-            capsys, cmd_effects=Exception("test exception")
+            capsys, cmd_effects=cmd_effects
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -3353,10 +3353,11 @@ class TestDockerCompose(_CheckTestBase):
 
     def test_success_standalone(self, capsys):
         """Test the success case."""
-        cmd_effects = [subprocess.SubprocessError, "docker-compose version 1.18.0"]
-        result, output = self.perform_check(
-            capsys, cmd_effects=cmd_effects
-        )
+        cmd_effects = [
+            subprocess.SubprocessError,
+            "docker-compose version 1.18.0",
+        ]
+        result, output = self.perform_check(capsys, cmd_effects=cmd_effects)
         assert (
             textwrap.dedent(output)
             == "PASS -- docker-compose (version 1.18.0)\n"
@@ -3366,9 +3367,7 @@ class TestDockerCompose(_CheckTestBase):
     def test_subproc_error(self, capsys):
         """Test a subprocess error being raised."""
         cmd_effects = [subprocess.SubprocessError, subprocess.SubprocessError]
-        result, output = self.perform_check(
-            capsys, cmd_effects=cmd_effects
-        )
+        result, output = self.perform_check(capsys, cmd_effects=cmd_effects)
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             FAIL -- docker-compose
@@ -3382,9 +3381,7 @@ class TestDockerCompose(_CheckTestBase):
     def test_no_version_match(self, capsys):
         """Test failure to match the version in the output."""
         cmd_effects = ["unexpected output", None]
-        result, output = self.perform_check(
-            capsys, cmd_effects=cmd_effects
-        )
+        result, output = self.perform_check(capsys, cmd_effects=cmd_effects)
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- docker-compose
@@ -3395,10 +3392,11 @@ class TestDockerCompose(_CheckTestBase):
 
     def test_old_version(self, capsys):
         """Test the version being too old."""
-        cmd_effects = [subprocess.SubprocessError, "docker-compose version 1.17.10"]
-        result, output = self.perform_check(
-            capsys, cmd_effects=cmd_effects
-        )
+        cmd_effects = [
+            subprocess.SubprocessError,
+            "docker-compose version 1.17.10",
+        ]
+        result, output = self.perform_check(capsys, cmd_effects=cmd_effects)
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             FAIL -- docker-compose
@@ -3411,9 +3409,7 @@ class TestDockerCompose(_CheckTestBase):
     def test_unexpected_error(self, capsys):
         """Test unexpected error being raised."""
         cmd_effects = [Exception("test exception"), None]
-        result, output = self.perform_check(
-            capsys, cmd_effects=cmd_effects
-        )
+        result, output = self.perform_check(capsys, cmd_effects=cmd_effects)
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- docker-compose

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -3342,9 +3342,8 @@ class TestDockerCompose(_CheckTestBase):
 
     def test_success_plugin(self, capsys):
         """Test the success case."""
-        result, output = self.perform_check(
-            capsys, cmd_effects="Docker Compose version v2.19.0"
-        )
+        cmd_effects = ["Docker Compose version v2.19.0", None]
+        result, output = self.perform_check(capsys, cmd_effects=cmd_effects)
         assert (
             textwrap.dedent(output)
             == "PASS -- docker-compose (version 2.19.0)\n"


### PR DESCRIPTION
### Summary

- Add Docker Compose v2 support to scripts `host-check` and `xr-compose`.
   - Support both plugin and standalone versions
- Add tests for `host-check` handling both plugin and standalone versions

### Testing
- Run `host-check` on a host with docker compose plugin
```
> ./host-check -e xr-compose
...
xr-compose checks
-----------------------
 PASS -- docker-compose (version 2.18.1)
 PASS -- PyYAML (installed)
 PASS -- Bridge iptables (disabled)
```
- Testing `xr-compose` on a host with docker compose plugin
```
> xr-compose -f <xr-compose-test.xr.yml> -i <xrd-control-plane-img> -l
[Success]
> docker ps
CONTAINER ID   IMAGE                                      COMMAND            CREATED         STATUS         PORTS     NAMES
c8fc9bf5317a   containers.cisco.com/xrdgen/ubuntu:20.04   "bash"             8 seconds ago   Up 6 seconds             source
21c3c3f8a8d3   auto/xrd/xrd-control-plane                 "/usr/sbin/init"   8 seconds ago   Up 5 seconds             xr-2
1705ddcf973b   auto/xrd/xrd-control-plane                 "/usr/sbin/init"   8 seconds ago   Up 6 seconds             xr-4-mgmt-only
c479f6b3cafe   auto/xrd/xrd-control-plane                 "/usr/sbin/init"   8 seconds ago   Up 5 seconds             xr-1
7296c743dcec   auto/xrd/xrd-control-plane                 "/usr/sbin/init"   8 seconds ago   Up 5 seconds             xr-3
```

### Checklist

<!-- See CONTRIBUTING.md. -->

- [x] Changelog updated (or not required)
  <!-- Is there any reason a user might care about the change?
       Have you changed any files that go in the release tarball?
       New GH release must be created after merging if new version added to the changelog. 
  -->
- [x] Static analysis and tests passing
   - Use `commit-check` script, or check GitHub Actions status.
