### PR TITLE
Modify Linux kernel version check to require at least version 4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 7.9.1.
 
+### v1.1.13 (2023-10-11)
+
+- Modify Linux kernel version check to require kernel version 4.6 or higher.
+
 ### v1.1.12 (2023-06-30)
 
 - Add Docker Compose v2 support to `host-check` and `xr-compose` scripts.

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -413,13 +413,13 @@ def check_kernel_version() -> CheckFuncReturn:
     except Exception:
         return (
             CheckState.ERROR,
-            f"Unable to check the kernel version with command {cmd!r} - must be at least version 4.0",
+            f"Unable to check the kernel version with command {cmd!r} - must be at least version 4.6",
         )
 
-    if version_tuple < (4, 0):
+    if version_tuple < (4, 6):
         return (
             CheckState.FAILED,
-            f"The kernel version is {version}, but at least version 4.0 is required.",
+            f"The kernel version is {version}, but at least version 4.6 is required.",
         )
 
     # Check for RHEL/CentOS 8.3 kernel version

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -970,8 +970,8 @@ class TestKernelVersion(_CheckTestBase):
 
     def test_success(self, capsys):
         """Test the success case."""
-        result, output = self.perform_check(capsys, cmd_effects="4.1")
-        assert textwrap.dedent(output) == "PASS -- Kernel version (4.1)\n"
+        result, output = self.perform_check(capsys, cmd_effects="4.6")
+        assert textwrap.dedent(output) == "PASS -- Kernel version (4.6)\n"
         assert result is CheckState.SUCCESS
 
     def test_subproc_error(self, capsys):
@@ -982,7 +982,7 @@ class TestKernelVersion(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Kernel version
-                     Unable to check the kernel version with command 'uname -r' - must be at least version 4.0
+                     Unable to check the kernel version with command 'uname -r' - must be at least version 4.6
             """
         )
         assert result is CheckState.ERROR
@@ -995,18 +995,29 @@ class TestKernelVersion(_CheckTestBase):
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             ERROR -- Kernel version
-                     Unable to check the kernel version with command 'uname -r' - must be at least version 4.0
+                     Unable to check the kernel version with command 'uname -r' - must be at least version 4.6
             """
         )
         assert result is CheckState.ERROR
 
-    def test_old_version(self, capsys):
+    def test_old_major_version(self, capsys):
         """Test the version being too old."""
         result, output = self.perform_check(capsys, cmd_effects="3.9.8")
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
             FAIL -- Kernel version
-                    The kernel version is 3.9, but at least version 4.0 is required.
+                    The kernel version is 3.9, but at least version 4.6 is required.
+            """
+        )
+        assert result is CheckState.FAILED
+
+    def test_old_minor_version(self, capsys):
+        """Test the version being too old."""
+        result, output = self.perform_check(capsys, cmd_effects="4.5")
+        assert textwrap.dedent(output) == textwrap.dedent(
+            """\
+            FAIL -- Kernel version
+                    The kernel version is 4.5, but at least version 4.6 is required.
             """
         )
         assert result is CheckState.FAILED


### PR DESCRIPTION
### Summary

Recent XRd cgroup improvements have meant that Linux kernel version 4.6 or higher is required. Update `host-check` to check for this.

### Checklist

<!-- See CONTRIBUTING.md. -->

- [ ] Changelog updated (or not required)
  <!-- Is there any reason a user might care about the change?
       Have you changed any files that go in the release tarball?
       New GH release must be created after merging if new version added to the changelog. 
  -->
- [ ] Static analysis and tests passing
   - Use `commit-check` script, or check GitHub Actions status.
