### PR TITLE
Update host-check rc and summary string for case of no errors/failures but warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 7.9.1.
 
 ### v1.1.14 (2023-11-15)
 
-- Modify the return code of 'host-check' so that 0 is returned if all checks pass, 10 is returned if there are any failures or errors and 11 is returned if there are warnings but no errors/failures.
+- Modify the return code of 'host-check' so that 0 is returned if all checks pass, 1 otherwise (including if warnings).
 
 ### v1.1.13 (2023-10-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 7.9.1.
 
 ### v1.1.14 (2023-11-15)
 
-- Modify the return code of 'host-check' so that 0 is returned if all checks pass, 1 otherwise (including if warnings).
+- `host-check` now summarizes failures and warnings separately". When testing both XR platforms, a failure for either is now treated as a failure overall.
 
 ### v1.1.13 (2023-10-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 7.9.1.
 
-### v1.1.14 (2023-11-15)
+### v1.1.14 (2023-11-24)
 
 - `host-check` now summarizes failures and warnings separately. When testing both XR platforms, a failure for either is now treated as a failure overall.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 7.9.1.
 
+### v1.1.14 (2023-11-15)
+
+- Modify the return code of 'host-check' so that 0 is returned if all checks pass, 10 is returned if there are any failures or errors and 11 is returned if there are warnings but no errors/failures.
+
 ### v1.1.13 (2023-10-11)
 
 - Modify Linux kernel version check to require kernel version 4.6 or higher.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 7.9.1.
 
 ### v1.1.14 (2023-11-15)
 
-- `host-check` now summarizes failures and warnings separately". When testing both XR platforms, a failure for either is now treated as a failure overall.
+- `host-check` now summarizes failures and warnings separately. When testing both XR platforms, a failure for either is now treated as a failure overall.
 
 ### v1.1.13 (2023-10-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 7.9.1.
 
-### v1.1.14 (2023-11-24)
+### v1.1.14 (2023-11-27)
 
 - `host-check` now summarizes failures and warnings separately. When testing both XR platforms, a failure for either is now treated as a failure overall.
 

--- a/docs/version-compatibility.md
+++ b/docs/version-compatibility.md
@@ -5,7 +5,7 @@ In some cases extra arguments will be required to continue using older XR releas
 
 ## v1.1
 
-Supports all XR versions between 7.7.1 and 7.10.1 (all released versions of XRd).
+Supports all XR versions between 7.7.1 and 7.9.1 (all released versions of XRd).
 
 See the v1.1 section below for compatibility with XR 7.7.1.
 

--- a/docs/version-compatibility.md
+++ b/docs/version-compatibility.md
@@ -5,7 +5,7 @@ In some cases extra arguments will be required to continue using older XR releas
 
 ## v1.1
 
-Supports all XR versions between 7.7.1 and 7.9.1 (all released versions of XRd).
+Supports all XR versions between 7.7.1 and 7.10.1 (all released versions of XRd).
 
 See the v1.1 section below for compatibility with XR 7.7.1.
 

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1604,16 +1604,24 @@ def perform_checks(checks: List[Check]) -> Mapping[str, CheckState]:
     return results
 
 
+class ExtraResults(NamedTuple):
+    """The results of any extra checks."""
+
+    supported: Set[str]
+    not_supported: Set[str]
+    errored: Set[str]
+    warned: Set[str]
+
+
 def run_if_extra_checks(
     extra_checks: Optional[List[str]] = None,
-) -> Tuple[Set[str], Set[str], Set[str], Set[str]]:
+) -> ExtraResults:
     """
-    Run the specified extra checks, printing the results and returning the
-    checks that succeeded, failed and errored.
+    Run the specified extra checks, printing the results.
     :param extra_checks:
         List of extra checks to perform.
     :returns:
-        Tuple of the checks that: succeeded, failed and errored and warned.
+        NamedTuple of sets of checks that succeeded, failed, errored and warned.
     """
     extras_supported = set()
     extras_not_supported = set()
@@ -1636,7 +1644,7 @@ def run_if_extra_checks(
             else:
                 extras_supported.add(extra_check)
 
-    return (
+    return ExtraResults(
         extras_supported,
         extras_not_supported,
         extras_errored,
@@ -1644,12 +1652,7 @@ def run_if_extra_checks(
     )
 
 
-def print_extra_checks_summary(
-    extras_supported: Set[str],
-    extras_not_supported: Set[str],
-    extras_errored: Set[str],
-    extras_warned: Set[str],
-) -> None:
+def print_extra_checks_summary(extra_results: ExtraResults) -> None:
     """
     Print a summary of the extra checks that passed and failed.
     :param extras_supported:
@@ -1662,16 +1665,24 @@ def print_extra_checks_summary(
         The checks that resulted in a warning.
     """
     print(f"{DASHED_LINE}")
-    if extras_supported:
-        print("Extra checks passed: " + ", ".join(sorted(extras_supported)))
-    if extras_not_supported:
+    if extra_results.supported:
         print(
-            "Extra checks failed: " + ", ".join(sorted(extras_not_supported))
+            "Extra checks passed: "
+            + ", ".join(sorted(extra_results.supported))
         )
-    if extras_errored:
-        print("Extra checks errored: " + ", ".join(sorted(extras_errored)))
-    if extras_warned:
-        print("Extra checks warned: " + ", ".join(sorted(extras_warned)))
+    if extra_results.not_supported:
+        print(
+            "Extra checks failed: "
+            + ", ".join(sorted(extra_results.not_supported))
+        )
+    if extra_results.errored:
+        print(
+            "Extra checks errored: " + ", ".join(sorted(extra_results.errored))
+        )
+    if extra_results.warned:
+        print(
+            "Extra checks warned: " + ", ".join(sorted(extra_results.warned))
+        )
 
 
 def run_checks_specific_platform(
@@ -1698,12 +1709,7 @@ def run_checks_specific_platform(
     plat_error = any(c is CheckState.ERROR for c in plat_results.values())
     plat_warning = any(c is CheckState.WARNING for c in plat_results.values())
 
-    (
-        extras_supported,
-        extras_not_supported,
-        extras_errored,
-        extras_warned,
-    ) = run_if_extra_checks(extra_checks)
+    extra_results = run_if_extra_checks(extra_checks)
 
     # Print a summary of what is and is not supported
     print(f"\n{DOUBLE_DASHED_LINE}")
@@ -1720,17 +1726,17 @@ def run_checks_specific_platform(
     else:
         print(f"Host environment set up correctly for {platform}")
     if extra_checks:
-        print_extra_checks_summary(
-            extras_supported,
-            extras_not_supported,
-            extras_errored,
-            extras_warned,
-        )
+        print_extra_checks_summary(extra_results)
     print(f"{DOUBLE_DASHED_LINE}")
 
-    if plat_failure or plat_error or extras_not_supported or extras_errored:
+    if (
+        plat_failure
+        or plat_error
+        or extra_results.not_supported
+        or extra_results.errored
+    ):
         rc = EXIT_ERROR
-    elif plat_warning or extras_warned:
+    elif plat_warning or extra_results.warned:
         rc = EXIT_WARNING
     else:
         rc = EXIT_SUCCESS
@@ -1775,12 +1781,7 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
         else:
             platforms_supported.add(platform)
 
-    (
-        extras_supported,
-        extras_not_supported,
-        extras_errored,
-        extras_warned,
-    ) = run_if_extra_checks(extra_checks)
+    extra_results = run_if_extra_checks(extra_checks)
 
     # Print a summary of what is and is not supported
     print(f"\n{DOUBLE_DASHED_LINE}")
@@ -1808,22 +1809,17 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
 
     # Print the result of any extra checks
     if extra_checks:
-        print_extra_checks_summary(
-            extras_supported,
-            extras_not_supported,
-            extras_errored,
-            extras_warned,
-        )
+        print_extra_checks_summary(extra_results)
     print(f"{DOUBLE_DASHED_LINE}")
 
     if (
         len(platforms_not_supported)
         + len(platforms_errored)
-        + len(extras_not_supported)
-        + len(extras_errored)
+        + len(extra_results.not_supported)
+        + len(extra_results.errored)
     ) > 0:
         rc = EXIT_ERROR
-    elif len(platforms_warned) + len(extras_warned) > 0:
+    elif len(platforms_warned) + len(extra_results.warned) > 0:
         rc = EXIT_WARNING
     else:
         rc = EXIT_SUCCESS

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1654,14 +1654,8 @@ def run_if_extra_checks(
 def print_extra_checks_summary(extra_results: ExtraResults) -> None:
     """
     Print a summary of the extra checks that passed and failed.
-    :param extras_supported:
-        The checks that were successful.
-    :param extras_not_supported:
-        The checks that were not successful.
-    :param extras_errored:
-        The checks that errored/failed to run.
-    :param extras_warned:
-        The checks that resulted in a warning.
+    :param extras_results:
+        The results of the extra checks.
     """
     print(f"{DASHED_LINE}")
     if extra_results.supported:
@@ -1788,19 +1782,20 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
         )
     if platforms_not_supported:
         print(
-            "XR platforms NOT supported: "
+            "!! XR platforms NOT supported: "
             + ", ".join(sorted(platforms_not_supported))
+            + " !!"
         )
     if platforms_errored:
         print(
-            "!! One or more platform checks could not be performed for XR platforms:   !!"
+            "!! One or more platform checks could not be performed for XR platforms: !!"
             + "\n      "
             + ",\n      ".join(sorted(platforms_errored))
             + "\n   See errors above."
         )
     if platforms_warned:
         print(
-            "!! One or more platform checks resulted in a warning for XR platforms:    !!"
+            "!! One or more platform checks resulted in a warning for XR platforms: !!"
             + "\n      "
             + ",\n      ".join(sorted(platforms_warned))
             + "\n   See warnings above."
@@ -1812,13 +1807,13 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
     print(f"{DOUBLE_DASHED_LINE}")
 
     if (
-        len(platforms_not_supported)
-        + len(platforms_errored)
-        + len(extra_results.not_supported)
-        + len(extra_results.errored)
-        + len(platforms_warned)
-        + len(extra_results.warned)
-    ) > 0:
+        platforms_not_supported
+        or platforms_errored
+        or extra_results.not_supported
+        or extra_results.errored
+        or platforms_warned
+        or extra_results.warned
+    ):
         rc = EXIT_ERROR
     else:
         rc = EXIT_SUCCESS

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1686,9 +1686,9 @@ def run_checks_specific_platform(
     :param extra_checks:
         A list of the extra checks.
     :return:
-        SUCCESS if platform is successful
-        ERROR if there are any failures or errors (including extra checks)
-        WARNING if there are warnings but no failures or errors (including
+        EXIT_SUCCESS if all checks were successful
+        EXIT_ERROR if there are any failures or errors (including extra checks)
+        EXIT_WARNING if there are warnings but no failures or errors (including
             extra checks)
     """
 
@@ -1743,9 +1743,9 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
     Run checks for all platforms and report which platforms are supported.
 
     :return:
-        SUCCESS if all XR platforms are supported
-        ERROR if there are any failures or errors (including extra tests)
-        WARNING if there are warnings but no failures or errors (including
+        EXIT_SUCCESS if all checks were successful
+        EXIT_ERROR if there are any failures or errors (including extra tests)
+        EXIT_WARNING if there are warnings but no failures or errors (including
             extra tests)
     """
     platforms_supported: Set[str] = set()

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -70,8 +70,7 @@ from typing import (
 
 # Exit codes
 EXIT_SUCCESS = 0
-EXIT_ERROR = 10
-EXIT_WARNING = 11
+EXIT_ERROR = 1
 
 
 INOTIFY_RECOMMENDED = 64000
@@ -1698,8 +1697,7 @@ def run_checks_specific_platform(
         A list of the extra checks.
     :return:
         EXIT_SUCCESS if all checks were successful
-        EXIT_ERROR if there are any failures or errors (including extra checks)
-        EXIT_WARNING if there are warnings but no failures or errors (including
+        EXIT_ERROR if there are any failures, warnings or errors (including
             extra checks)
     """
 
@@ -1734,10 +1732,10 @@ def run_checks_specific_platform(
         or plat_error
         or extra_results.not_supported
         or extra_results.errored
+        or plat_warning
+        or extra_results.warned
     ):
         rc = EXIT_ERROR
-    elif plat_warning or extra_results.warned:
-        rc = EXIT_WARNING
     else:
         rc = EXIT_SUCCESS
 
@@ -1750,8 +1748,7 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
 
     :return:
         EXIT_SUCCESS if all checks were successful
-        EXIT_ERROR if there are any failures or errors (including extra tests)
-        EXIT_WARNING if there are warnings but no failures or errors (including
+        EXIT_ERROR if there are any failures, warnings or errors (including
             extra tests)
     """
     platforms_supported: Set[str] = set()
@@ -1819,10 +1816,10 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
         + len(platforms_errored)
         + len(extra_results.not_supported)
         + len(extra_results.errored)
+        + len(platforms_warned)
+        + len(extra_results.warned)
     ) > 0:
         rc = EXIT_ERROR
-    elif len(platforms_warned) + len(extra_results.warned) > 0:
-        rc = EXIT_WARNING
     else:
         rc = EXIT_SUCCESS
 

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -45,7 +45,6 @@ import shlex
 import subprocess
 import textwrap
 from dataclasses import dataclass
-from enum import Enum
 from typing import (
     Any,
     Callable,
@@ -1715,7 +1714,9 @@ def run_checks_specific_platform(
             "!! One or more platform checks could not be performed, see errors above !!"
         )
     elif plat_warning:
-        print("!! One or more platform checks resulted in a warning, see warnings above !!")
+        print(
+            "!! One or more platform checks resulted in a warning, see warnings above !!"
+        )
     else:
         print(f"Host environment set up correctly for {platform}")
     if extra_checks:
@@ -1795,12 +1796,14 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
     if platforms_errored:
         print(
             "!! One or more platform checks could not be performed for XR platforms:\n    "
-            + ", ".join(sorted(platforms_errored)) + " (see errors above) !!"
+            + ", ".join(sorted(platforms_errored))
+            + " (see errors above) !!"
         )
     if platforms_warned:
         print(
             "!! One or more platform checks resulted in a warning for XR platforms:\n    "
-            + ", ".join(sorted(platforms_warned)) + " (see warnings above) !!"
+            + ", ".join(sorted(platforms_warned))
+            + " (see warnings above) !!"
         )
 
     # Print the result of any extra checks
@@ -1815,10 +1818,10 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
 
     if (
         len(platforms_not_supported)
-            + len(platforms_errored)
-            + len(extras_not_supported)
-            + len(extras_errored)
-        ) > 0:
+        + len(platforms_errored)
+        + len(extras_not_supported)
+        + len(extras_errored)
+    ) > 0:
         rc = EXIT_ERROR
     elif len(platforms_warned) + len(extras_warned) > 0:
         rc = EXIT_WARNING

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1796,15 +1796,17 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
         )
     if platforms_errored:
         print(
-            "!! One or more platform checks could not be performed for XR platforms:\n    "
-            + ", ".join(sorted(platforms_errored))
-            + " (see errors above) !!"
+            "!! One or more platform checks could not be performed for XR platforms:   !!"
+            + "\n      "
+            + ",\n      ".join(sorted(platforms_errored))
+            + "\n   See errors above."
         )
     if platforms_warned:
         print(
-            "!! One or more platform checks resulted in a warning for XR platforms:\n    "
-            + ", ".join(sorted(platforms_warned))
-            + " (see warnings above) !!"
+            "!! One or more platform checks resulted in a warning for XR platforms:    !!"
+            + "\n      "
+            + ",\n      ".join(sorted(platforms_warned))
+            + "\n   See warnings above."
         )
 
     # Print the result of any extra checks

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -45,6 +45,7 @@ import shlex
 import subprocess
 import textwrap
 from dataclasses import dataclass
+from enum import Enum
 from typing import (
     Any,
     Callable,
@@ -66,6 +67,13 @@ from typing import (
 # -----------------------------------------------------------------------------
 # Globals
 # -----------------------------------------------------------------------------
+
+
+# Exit codes
+EXIT_SUCCESS = 0
+EXIT_ERROR = 10
+EXIT_WARNING = 11
+
 
 INOTIFY_RECOMMENDED = 64000
 INOTIFY_PER_CONTAINER = 4000
@@ -319,12 +327,13 @@ class CheckState(enum.Enum):
     # 'success' check states
     SUCCESS = "success"
     NEUTRAL = "neutral"
-    # 'failure' check states
+    # 'warning' check states
     WARNING = "warning"
+    # 'failure' check states
     SKIPPED = "skipped"
     FAILED = "failed"
     # Check state for when the check fails to run/errors
-    # Note: this is neither 'success' nor 'failure'
+    # Note: this is not 'success', 'warning' or 'failure'
     ERROR = "error"
 
     def is_failure(self) -> bool:
@@ -335,7 +344,6 @@ class CheckState(enum.Enum):
         return self in [
             CheckState.FAILED,
             CheckState.SKIPPED,
-            CheckState.WARNING,
         ]
 
 
@@ -1599,18 +1607,19 @@ def perform_checks(checks: List[Check]) -> Mapping[str, CheckState]:
 
 def run_if_extra_checks(
     extra_checks: Optional[List[str]] = None,
-) -> Tuple[Set[str], Set[str], Set[str]]:
+) -> Tuple[Set[str], Set[str], Set[str], Set[str]]:
     """
     Run the specified extra checks, printing the results and returning the
     checks that succeeded, failed and errored.
     :param extra_checks:
         List of extra checks to perform.
     :returns:
-        Tuple of the checks that: succeeded, failed and errored.
+        Tuple of the checks that: succeeded, failed and errored and warned.
     """
     extras_supported = set()
     extras_not_supported = set()
     extras_errored = set()
+    extras_warned = set()
 
     if extra_checks:
         print("")  # insert a newline
@@ -1623,16 +1632,24 @@ def run_if_extra_checks(
                 extras_not_supported.add(extra_check)
             elif any(c is CheckState.ERROR for c in extra_results.values()):
                 extras_errored.add(extra_check)
+            elif any(c is CheckState.WARNING for c in extra_results.values()):
+                extras_warned.add(extra_check)
             else:
                 extras_supported.add(extra_check)
 
-    return extras_supported, extras_not_supported, extras_errored
+    return (
+        extras_supported,
+        extras_not_supported,
+        extras_errored,
+        extras_warned,
+    )
 
 
 def print_extra_checks_summary(
     extras_supported: Set[str],
     extras_not_supported: Set[str],
     extras_errored: Set[str],
+    extras_warned: Set[str],
 ) -> None:
     """
     Print a summary of the extra checks that passed and failed.
@@ -1642,6 +1659,8 @@ def print_extra_checks_summary(
         The checks that were not successful.
     :param extras_errored:
         The checks that errored/failed to run.
+    :param extras_warned:
+        The checks that resulted in a warning.
     """
     print(f"{DASHED_LINE}")
     if extras_supported:
@@ -1652,11 +1671,13 @@ def print_extra_checks_summary(
         )
     if extras_errored:
         print("Extra checks errored: " + ", ".join(sorted(extras_errored)))
+    if extras_warned:
+        print("Extra checks warned: " + ", ".join(sorted(extras_warned)))
 
 
 def run_checks_specific_platform(
     platform: str, extra_checks: List[str]
-) -> bool:
+) -> int:
     """
     Run checks for the given platform (including the base checks that are
     required for all platforms).
@@ -1666,18 +1687,23 @@ def run_checks_specific_platform(
     :param extra_checks:
         A list of the extra checks.
     :return:
-        Whether all checks that were performed succeeded.
+        SUCCESS if platform is successful
+        ERROR if there are any failures or errors (including extra checks)
+        WARNING if there are warnings but no failures or errors (including
+            extra checks)
     """
 
     print_heading(f"Platform checks - {platform}")
     plat_results = perform_checks(BASE_CHECKS + PLATFORM_CHECKS_MAP[platform])
     plat_failure = any(check.is_failure() for check in plat_results.values())
     plat_error = any(c is CheckState.ERROR for c in plat_results.values())
+    plat_warning = any(c is CheckState.WARNING for c in plat_results.values())
 
     (
         extras_supported,
         extras_not_supported,
         extras_errored,
+        extras_warned,
     ) = run_if_extra_checks(extra_checks)
 
     # Print a summary of what is and is not supported
@@ -1688,29 +1714,43 @@ def run_checks_specific_platform(
         print(
             "!! One or more platform checks could not be performed, see errors above !!"
         )
+    elif plat_warning:
+        print("!! One or more platform checks resulted in a warning, see warnings above !!")
     else:
         print(f"Host environment set up correctly for {platform}")
     if extra_checks:
         print_extra_checks_summary(
-            extras_supported, extras_not_supported, extras_errored
+            extras_supported,
+            extras_not_supported,
+            extras_errored,
+            extras_warned,
         )
     print(f"{DOUBLE_DASHED_LINE}")
 
-    return not (
-        plat_failure or plat_error or extras_not_supported or extras_errored
-    )
+    if plat_failure or plat_error or extras_not_supported or extras_errored:
+        rc = EXIT_ERROR
+    elif plat_warning or extras_warned:
+        rc = EXIT_WARNING
+    else:
+        rc = EXIT_SUCCESS
+
+    return rc
 
 
-def run_checks_all_platforms(extra_checks: List[str]) -> bool:
+def run_checks_all_platforms(extra_checks: List[str]) -> int:
     """
     Run checks for all platforms and report which platforms are supported.
 
     :return:
-        Whether at least one XR platform is supported.
+        SUCCESS if all XR platforms are supported
+        ERROR if there are any failures or errors (including extra tests)
+        WARNING if there are warnings but no failures or errors (including
+            extra tests)
     """
     platforms_supported: Set[str] = set()
     platforms_not_supported: Set[str] = set()
     platforms_errored: Set[str] = set()
+    platforms_warned: Set[str] = set()
 
     print_heading("Platform checks")
     print_subheading("base checks")
@@ -1727,6 +1767,10 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
             result is CheckState.ERROR for result in base_and_plat_results
         ):
             platforms_errored.add(platform)
+        elif any(
+            result is CheckState.WARNING for result in base_and_plat_results
+        ):
+            platforms_warned.add(platform)
         else:
             platforms_supported.add(platform)
 
@@ -1734,6 +1778,7 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
         extras_supported,
         extras_not_supported,
         extras_errored,
+        extras_warned,
     ) = run_if_extra_checks(extra_checks)
 
     # Print a summary of what is and is not supported
@@ -1749,16 +1794,38 @@ def run_checks_all_platforms(extra_checks: List[str]) -> bool:
         )
     if platforms_errored:
         print(
-            "!! One or more platform checks could not be performed, see errors above !!"
+            "!! One or more platform checks could not be performed for XR platforms:\n    "
+            + ", ".join(sorted(platforms_errored)) + " (see errors above) !!"
         )
+    if platforms_warned:
+        print(
+            "!! One or more platform checks resulted in a warning for XR platforms:\n    "
+            + ", ".join(sorted(platforms_warned)) + " (see warnings above) !!"
+        )
+
     # Print the result of any extra checks
     if extra_checks:
         print_extra_checks_summary(
-            extras_supported, extras_not_supported, extras_errored
+            extras_supported,
+            extras_not_supported,
+            extras_errored,
+            extras_warned,
         )
     print(f"{DOUBLE_DASHED_LINE}")
 
-    return len(platforms_supported) > 0
+    if (
+        len(platforms_not_supported)
+            + len(platforms_errored)
+            + len(extras_not_supported)
+            + len(extras_errored)
+        ) > 0:
+        rc = EXIT_ERROR
+    elif len(platforms_warned) + len(extras_warned) > 0:
+        rc = EXIT_WARNING
+    else:
+        rc = EXIT_SUCCESS
+
+    return rc
 
 
 def parse_args(argv: List[str]) -> argparse.Namespace:
@@ -1786,12 +1853,10 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
 def main(argv: List[str]) -> NoReturn:
     args = parse_args(argv)
     if args.platform:
-        success = run_checks_specific_platform(
-            args.platform, args.extra_checks
-        )
+        rc = run_checks_specific_platform(args.platform, args.extra_checks)
     else:
-        success = run_checks_all_platforms(args.extra_checks)
-    sys.exit(0 if success else 1)
+        rc = run_checks_all_platforms(args.extra_checks)
+    sys.exit(rc)
 
 
 if __name__ == "__main__":

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -66,7 +66,6 @@ def perform_check(
     files: Optional[Union[Tuple[str, Any], List[Tuple[str, Any]]]] = None,
     deps: Optional[List[str]] = None,
     failed_deps: Optional[List[str]] = None,
-    warned_deps: Optional[List[str]] = None,
 ) -> Tuple[CheckState, str]:
     """
     Perform a single host check and return whether it succeeded and the output.
@@ -89,8 +88,6 @@ def perform_check(
         Any dependencies to check that the host check is declared to have.
     :param failed_deps:
         Any dependencies to treat as failed.
-    :param warned_deps:
-        Any dependencies to treat as warned.
     :return:
         The result of the check and the output from the check.
     """
@@ -102,8 +99,6 @@ def perform_check(
         for d in deps:
             if failed_deps and d in failed_deps:
                 check_state = host_check.CheckState.FAILED
-            elif warned_deps and d in warned_deps:
-                check_state = host_check.CheckState.WARNING
             else:
                 check_state = host_check.CheckState.SUCCESS
             checks.append(

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -760,7 +760,6 @@ XR platforms NOT supported: xrd-control-plane, xrd-vrouter
         assert output == cli_output
         assert exit_code == EXIT_ERROR
 
-
     def test_no_plats_supported(self, capsys):
         """Test no platforms being supported when host-check is run without arguments."""
         exit_code, output = self.run_host_check(
@@ -826,7 +825,7 @@ XR platforms NOT supported: xrd-vrouter
             capsys,
             [],
             failing_checks=["Hugepages"],
-            warning_checks=["Kernel version"]
+            warning_checks=["Kernel version"],
         )
         cli_output = f"""\
 ==============================
@@ -933,8 +932,8 @@ Extra checks failed: xr-compose
         assert output == cli_output
         assert exit_code == EXIT_ERROR
 
-    def test_extra_check_warning(self, capsys):
-        """Test a specified extra check warning."""
+    def test_plat_specified_extra_check_warning(self, capsys):
+        """Test a specified extra check warning with the platform specified."""
         exit_code, output = self.run_host_check(
             capsys,
             ["-p", "xrd-control-plane", "-e", "docker", "xr-compose"],

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -34,7 +34,6 @@ host_check = utils.import_path(HOST_CHECK_SCRIPT)
 CheckState = host_check.CheckState
 Check = host_check.Check
 EXIT_SUCCESS = host_check.EXIT_SUCCESS
-EXIT_WARNING = host_check.EXIT_WARNING
 EXIT_ERROR = host_check.EXIT_ERROR
 
 # ------------------------------------------------------------------------------
@@ -565,7 +564,7 @@ Extra checks warned: docker
 ============================================================================
 """
         assert output == cli_output
-        assert exit_code == EXIT_WARNING
+        assert exit_code == EXIT_ERROR
 
     def test_plat_specified_check_failing(self, capsys):
         """Test a platform check failing when host-check is run with arguments."""
@@ -625,7 +624,7 @@ Checks: {BASE_CHECKS_STR}, {CONTROL_PLANE_CHECKS_STR}
 ============================================================================
 """
         assert output == cli_output
-        assert exit_code == EXIT_WARNING
+        assert exit_code == EXIT_ERROR
 
     def test_plat_specified_check_warning_failing(self, capsys):
         """
@@ -720,7 +719,7 @@ Checks: {VROUTER_CHECKS_STR}
 ============================================================================
 """
         assert output == cli_output
-        assert exit_code == EXIT_WARNING
+        assert exit_code == EXIT_ERROR
 
     def test_base_check_warning_failing(self, capsys):
         """
@@ -965,7 +964,7 @@ Extra checks warned: xr-compose
 ============================================================================
 """
         assert output == cli_output
-        assert exit_code == EXIT_WARNING
+        assert exit_code == EXIT_ERROR
 
     def test_extra_check_erroring_plat(self, capsys):
         """Test a specified extra check erroring."""

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -677,7 +677,7 @@ xrd-vrouter checks
 Checks: {VROUTER_CHECKS_STR}
 
 ============================================================================
-!! One or more platform checks could not be performed for XR platforms:   !!
+!! One or more platform checks could not be performed for XR platforms: !!
       xrd-control-plane,
       xrd-vrouter
    See errors above.
@@ -712,7 +712,7 @@ xrd-vrouter checks
 Checks: {VROUTER_CHECKS_STR}
 
 ============================================================================
-!! One or more platform checks resulted in a warning for XR platforms:    !!
+!! One or more platform checks resulted in a warning for XR platforms: !!
       xrd-control-plane,
       xrd-vrouter
    See warnings above.
@@ -751,7 +751,7 @@ xrd-vrouter checks
 Checks: {VROUTER_CHECKS_STR}
 
 ============================================================================
-XR platforms NOT supported: xrd-control-plane, xrd-vrouter
+!! XR platforms NOT supported: xrd-control-plane, xrd-vrouter !!
 ============================================================================
 """
         print(output)
@@ -781,7 +781,7 @@ xrd-vrouter checks
 Checks: {VROUTER_CHECKS_STR}
 
 ============================================================================
-XR platforms NOT supported: xrd-control-plane, xrd-vrouter
+!! XR platforms NOT supported: xrd-control-plane, xrd-vrouter !!
 ============================================================================
 """
         assert output == cli_output
@@ -811,7 +811,7 @@ Checks: {VROUTER_CHECKS_STR}
 
 ============================================================================
 XR platforms supported: xrd-control-plane
-XR platforms NOT supported: xrd-vrouter
+!! XR platforms NOT supported: xrd-vrouter !!
 ============================================================================
 """
         assert output == cli_output
@@ -843,8 +843,8 @@ xrd-vrouter checks
 Checks: {VROUTER_CHECKS_STR}
 
 ============================================================================
-XR platforms NOT supported: xrd-vrouter
-!! One or more platform checks resulted in a warning for XR platforms:    !!
+!! XR platforms NOT supported: xrd-vrouter !!
+!! One or more platform checks resulted in a warning for XR platforms: !!
       xrd-control-plane
    See warnings above.
 ============================================================================

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -678,8 +678,10 @@ xrd-vrouter checks
 Checks: {VROUTER_CHECKS_STR}
 
 ============================================================================
-!! One or more platform checks could not be performed for XR platforms:
-    xrd-control-plane, xrd-vrouter (see errors above) !!
+!! One or more platform checks could not be performed for XR platforms:   !!
+      xrd-control-plane,
+      xrd-vrouter
+   See errors above.
 ============================================================================
 """
         print(output)
@@ -711,8 +713,10 @@ xrd-vrouter checks
 Checks: {VROUTER_CHECKS_STR}
 
 ============================================================================
-!! One or more platform checks resulted in a warning for XR platforms:
-    xrd-control-plane, xrd-vrouter (see warnings above) !!
+!! One or more platform checks resulted in a warning for XR platforms:    !!
+      xrd-control-plane,
+      xrd-vrouter
+   See warnings above.
 ============================================================================
 """
         assert output == cli_output
@@ -841,8 +845,9 @@ Checks: {VROUTER_CHECKS_STR}
 
 ============================================================================
 XR platforms NOT supported: xrd-vrouter
-!! One or more platform checks resulted in a warning for XR platforms:
-    xrd-control-plane (see warnings above) !!
+!! One or more platform checks resulted in a warning for XR platforms:    !!
+      xrd-control-plane
+   See warnings above.
 ============================================================================
 """
         assert output == cli_output


### PR DESCRIPTION
### Summary

Updated host-check summary message in the case of some checks failing/error and some checks warning but none failing/erroring.

Also, changed the behaviour of host-check when passed no arguments. Now, a non-zero error code is returned if checks for any platform fail/error/warn.

Tests updated to reflect the new behaviour for checks resulting in warnings and when no platform is specified.


### Output

In the case of warnings but no errors get example output:
```
(venv) [ebeaty@sjc-ads-8712 GIT(dev/ebeaty-cisco) xrd-tools]$ scripts/host-check -p xrd-control-plane 
==============================
Platform checks - xrd-control-plane
==============================
 PASS -- CPU architecture (x86_64)
 PASS -- CPU cores (16)
 PASS -- Kernel version (4.18)
 PASS -- Base kernel modules[...]
 PASS -- Cgroups (v1)
 WARN -- Inotify max user instances[...]
 PASS -- Inotify max user watches[...]
 WARN -- Socket kernel parameters[...]
 WARN -- UDP kernel parameters[...]
 INFO -- Core pattern (core files managed by XR)
 PASS -- ASLR (full randomization)
 INFO -- Linux Security Modules (No LSMs are enabled)
 PASS -- Kernel module parameters[...]
 PASS -- RAM [...]

============================================================================
!! One or more platform checks resulted in a warning, see warnings above !!
============================================================================
```

When checking both control-plane and vRouter with one failing the other warning get output:
```
(venv) [ebeaty@sjc-ads-8712 GIT(dev/ebeaty-cisco) xrd-tools]$ scripts/host-check 
==============================
Platform checks
==============================

base checks
-----------------------
 PASS -- CPU architecture (x86_64)
 PASS -- CPU cores (16)
 PASS -- Kernel version (4.18)
 PASS -- Base kernel modules[...]
 PASS -- Cgroups (v1)
 WARN -- Inotify max user instances[...]
 PASS -- Inotify max user watches[...]
 WARN -- Socket kernel parameters[...]
 WARN -- UDP kernel parameters[...]
 INFO -- Core pattern (core files managed by XR)
 PASS -- ASLR (full randomization)
 INFO -- Linux Security Modules (No LSMs are enabled)
 PASS -- Kernel module parameters[...]

xrd-control-plane checks
-----------------------
 PASS -- RAM[...]

xrd-vrouter checks
-----------------------
 PASS -- CPU extensions (sse4_1, sse4_2, ssse3)
 PASS -- RAM[...]
 FAIL -- Hugepages[...]
 FAIL -- Interface kernel driver[...]
 SKIP -- IOMMU[...]
 PASS -- Shared memory pages max size (17179869184.0 GiB)
 FAIL -- Real-time Group Scheduling[...]

============================================================================
!! XR platforms NOT supported: xrd-vrouter !!
!! One or more platform checks resulted in a warning for XR platforms: !!
      xrd-control-plane
   See warnings above.
============================================================================
```

### Checklist

<!-- See CONTRIBUTING.md. -->

- [ ] Changelog updated (or not required)
  <!-- Is there any reason a user might care about the change?
       Have you changed any files that go in the release tarball?
       New GH release must be created after merging if new version added to the changelog. 
  -->
- [ ] Static analysis and tests passing
   - Use `commit-check` script, or check GitHub Actions status.
