### PR TITLE
Separate IOMMU and PCI device checks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 7.10.1.
 
+### v1.1.14 (2024-03-04)
+
+- `host-check` now has separate checks for IOMMU being enabled and PCI device availability.
+
 ### v1.1.14 (2023-11-27)
 
 - `host-check` now summarizes failures and warnings separately. When testing both XR platforms, a failure for either is now treated as a failure overall.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 The v1 release supports Cisco IOS-XR release versions from 7.7.1 to 7.10.1.
 
-### v1.1.14 (2024-03-04)
+### v1.1.15 (2024-03-04)
 
 - `host-check` now has separate checks for IOMMU being enabled and PCI device availability.
 

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1126,7 +1126,8 @@ def check_pci_devices() -> CheckFuncReturn:
                 if f.read().strip().upper() in ("Y", "1"):
                     require_iommu = False
         except OSError:
-            # If the no-IOMMU file does not exist, then no-IOMMU mode can't be enabled.
+            # If the no-IOMMU file does not exist, then no-IOMMU mode can't be
+            enabled.
             pass
     else:
         require_iommu = False

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1117,7 +1117,8 @@ def check_pci_devices() -> CheckFuncReturn:
             os.path.basename(p) for p in glob.glob(iommu_dev_filepath)
         ]
     except Exception:
-        pass
+        # If getting the directory fails, then assume IOMMU is not enabled
+        iommu_devices = []
 
     # List the network PCI devices
     try:
@@ -1148,7 +1149,7 @@ def check_pci_devices() -> CheckFuncReturn:
         if not network_devices:
             return (
                 CheckState.WARNING,
-                "IOMMU enabled for vfio-pci, but no network PCI devices found.",
+                "No PCI network devices found with IOMMU enabled for vfio-pci.",
             )
 
     net_devs_list = []

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1107,7 +1107,7 @@ def check_iommu() -> CheckFuncReturn:
     return (CheckState.SUCCESS, "IOMMU enabled for vfio-pci.")
 
 
-def check_pci() -> CheckFuncReturn:
+def check_pci_devices() -> CheckFuncReturn:
     """Check PCI devices are available."""
 
     # Check if IOMMU is enabled on the host by getting the IOMMU devices
@@ -1519,7 +1519,7 @@ VROUTER_CHECKS = [
     Check("Hugepages", check_hugepages, []),
     Check("Interface kernel driver", check_interface_kernel_driver, []),
     Check("IOMMU", check_iommu, ["Interface kernel driver"]),
-    Check("PCI", check_pci, ["IOMMU"]),
+    Check("PCI devices", check_pci_devices, ["IOMMU"]),
     Check("Shared memory pages max size", check_shmem_pages_max_size, []),
     Check("Real-time Group Scheduling", check_realtime_group_sched, []),
 ]

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1127,7 +1127,7 @@ def check_pci_devices() -> CheckFuncReturn:
                     require_iommu = False
         except OSError:
             # If the no-IOMMU file does not exist, then no-IOMMU mode can't be
-            enabled.
+            # enabled.
             pass
     else:
         require_iommu = False

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1104,6 +1104,21 @@ def check_iommu() -> CheckFuncReturn:
             f"Unable to check if IOMMU is enabled by listing {iommu_dev_filepath}.\n"
             + recommendation,
         )
+    return (CheckState.SUCCESS, "IOMMU enabled for vfio-pci.")
+
+
+def check_pci() -> CheckFuncReturn:
+    """Check PCI devices are available."""
+
+    # Check if IOMMU is enabled on the host by getting the IOMMU devices
+    iommu_dev_filepath = "/sys/class/iommu/*/devices/*"
+    try:
+        iommu_devices = [
+            os.path.basename(p) for p in glob.glob(iommu_dev_filepath)
+        ]
+    except Exception:
+        pass
+
     # List the network PCI devices
     try:
         cmd = "lshw -businfo -c network"
@@ -1112,8 +1127,6 @@ def check_iommu() -> CheckFuncReturn:
             r"pci@([\da-f]{4}:[\da-f]{2}:[\da-f]{2}\.[\da-f])\s+(\S+)", output
         )
         if not matches:
-            # This should always be a warning - we need PCI devices whether
-            # we're using igb_uio or vfio-pci.
             return CheckState.WARNING, "no PCI network devices found"
         network_devices = set()
         net_devices_dict = {}
@@ -1126,22 +1139,24 @@ def check_iommu() -> CheckFuncReturn:
         return (
             CheckState.ERROR,
             f"The cmd {cmd!r} failed - unable to\n"
-            "determine the network devices on the host. IOMMU is enabled.",
+            "determine the network devices on the host.",
         )
-    net_iommu_devices = network_devices & set(iommu_devices)
-    if not net_iommu_devices:
-        return (
-            warning_state,
-            "IOMMU enabled for vfio-pci, but no network PCI devices found.",
-        )
-    net_iommu_devs_list = []
-    for device in sorted(net_iommu_devices):
-        net_iommu_devs_list.append(
-            net_devices_dict[device] + " (" + device + ")"
-        )
+
+    # If in IOMMU mode then check if the network devices are in the IOMMU group
+    if iommu_devices:
+        network_devices &= set(iommu_devices)
+        if not network_devices:
+            return (
+                CheckState.WARNING,
+                "IOMMU enabled for vfio-pci, but no network PCI devices found.",
+            )
+
+    net_devs_list = []
+    for device in sorted(network_devices):
+        net_devs_list.append(net_devices_dict[device] + " (" + device + ")")
     dev_output = ""
-    for count, dev in enumerate(net_iommu_devs_list, start=1):
-        if count == len(net_iommu_devs_list):
+    for count, dev in enumerate(net_devs_list, start=1):
+        if count == len(net_devs_list):
             dev_output = dev_output + f"{dev}"
         elif count % 3 != 0:
             dev_output = dev_output + f"{dev}, "
@@ -1149,8 +1164,7 @@ def check_iommu() -> CheckFuncReturn:
             dev_output = dev_output + f"{dev},\n"
     return (
         CheckState.SUCCESS,
-        "IOMMU enabled for vfio-pci with the following PCI device(s):\n"
-        + dev_output,
+        "The following PCI device(s) are available:\n" + dev_output,
     )
 
 
@@ -1505,6 +1519,7 @@ VROUTER_CHECKS = [
     Check("Hugepages", check_hugepages, []),
     Check("Interface kernel driver", check_interface_kernel_driver, []),
     Check("IOMMU", check_iommu, ["Interface kernel driver"]),
+    Check("PCI", check_pci, ["IOMMU"]),
     Check("Shared memory pages max size", check_shmem_pages_max_size, []),
     Check("Real-time Group Scheduling", check_realtime_group_sched, []),
 ]

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1109,16 +1109,38 @@ def check_iommu() -> CheckFuncReturn:
 
 def check_pci_devices() -> CheckFuncReturn:
     """Check PCI devices are available."""
+    # If only vfio-pci is supported (and it is not in no-IOMMU mode), then
+    # check for PCI network devices in IOMMU group, otherwise check for any
+    # PCI network devices.
+    if (
+        PCIDriver("vfio-pci").is_supported()
+        and not PCIDriver("igb_uio").is_supported()
+    ):
+        require_iommu = True
+        # Overide require_iommu if no-IOMMU mode is enabled
+        noiommu_filepath = (
+            "/sys/module/vfio/parameters/enable_unsafe_noiommu_mode"
+        )
+        try:
+            with open(noiommu_filepath, "r", encoding="utf-8") as f:
+                if f.read().strip().upper() in ("Y", "1"):
+                    require_iommu = False
+        except OSError:
+            # If the no-IOMMU file does not exist, then no-IOMMU mode can't be enabled.
+            pass
+    else:
+        require_iommu = False
 
-    # Check if IOMMU is enabled on the host by getting the IOMMU devices
-    iommu_dev_filepath = "/sys/class/iommu/*/devices/*"
-    try:
-        iommu_devices = [
-            os.path.basename(p) for p in glob.glob(iommu_dev_filepath)
-        ]
-    except Exception:
-        # If getting the directory fails, then assume IOMMU is not enabled
-        iommu_devices = []
+    if require_iommu:
+        # Get IOMMU devices
+        iommu_dev_filepath = "/sys/class/iommu/*/devices/*"
+        try:
+            iommu_devices = [
+                os.path.basename(p) for p in glob.glob(iommu_dev_filepath)
+            ]
+        except Exception:
+            # If getting the directory fails, then assume IOMMU is not enabled
+            iommu_devices = []
 
     # List the network PCI devices
     try:
@@ -1144,7 +1166,7 @@ def check_pci_devices() -> CheckFuncReturn:
         )
 
     # If in IOMMU mode then check if the network devices are in the IOMMU group
-    if iommu_devices:
+    if require_iommu:
         network_devices &= set(iommu_devices)
         if not network_devices:
             return (
@@ -1520,7 +1542,7 @@ VROUTER_CHECKS = [
     Check("Hugepages", check_hugepages, []),
     Check("Interface kernel driver", check_interface_kernel_driver, []),
     Check("IOMMU", check_iommu, ["Interface kernel driver"]),
-    Check("PCI devices", check_pci_devices, ["IOMMU"]),
+    Check("PCI devices", check_pci_devices, ["Interface kernel driver"]),
     Check("Shared memory pages max size", check_shmem_pages_max_size, []),
     Check("Real-time Group Scheduling", check_realtime_group_sched, []),
 ]

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -3263,7 +3263,7 @@ pci@0000:00:01.0  device2     network    Ethernet interface
 
     def test_no_iommu_devices(self, capsys):
         """
-        Test the case where no IOMMU devices are found when in IOMMU mode.
+        Test the case where no IOMMU network devices are found when in IOMMU mode.
 
         """
         lshw_output = """\

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -3167,11 +3167,11 @@ pci@0000:00:01.0  device2     network    Ethernet interface
         assert result is CheckState.NEUTRAL
 
 
-class TestPCI(_CheckTestBase):
-    """Tests for the IOMMU check."""
+class TestPCIDevices(_CheckTestBase):
+    """Tests for the PCI devices check."""
 
     check_group = "xrd-vrouter"
-    check_name = "PCI"
+    check_name = "PCI devices"
     deps = ["IOMMU"]
     cmds = ["lshw -businfo -c network"]
     files = []
@@ -3204,7 +3204,7 @@ pci@0000:00:01.0  device2     network    Ethernet interface
             )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-            PASS -- PCI
+            PASS -- PCI devices
                     The following PCI device(s) are available:
                     device1 (0000:00:00.0), device2 (0000:00:01.0), device3 (0000:00:02.0)
             """
@@ -3231,7 +3231,7 @@ pci@0000:00:01.0  device2     network    Ethernet interface
         )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-            PASS -- PCI
+            PASS -- PCI devices
                     The following PCI device(s) are available:
                     device1 (0000:00:00.0), device2 (0000:00:01.0), device3 (0000:00:02.0),
                     device4 (0000:00:1f.2)
@@ -3256,7 +3256,7 @@ pci@0000:00:1f.2  docker0     network    Ethernet interface
             )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-            WARN -- PCI
+            WARN -- PCI devices
                     IOMMU enabled for vfio-pci, but no network PCI devices found.
             """
         )
@@ -3280,7 +3280,7 @@ pci@0000:00:1f.2  docker0     network    Ethernet interface
             )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-            ERROR -- PCI
+            ERROR -- PCI devices
                      The cmd 'lshw -businfo -c network' failed - unable to
                      determine the network devices on the host.
             """
@@ -3311,7 +3311,7 @@ Bus info          Device      Class      Description
             )
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
-            WARN -- PCI (no PCI network devices found)
+            WARN -- PCI devices (no PCI network devices found)
             """
         )
         assert result is CheckState.WARNING
@@ -3321,7 +3321,7 @@ Bus info          Device      Class      Description
         result, output = self.perform_check(capsys, failed_deps=self.deps)
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-            SKIP -- PCI
+            SKIP -- PCI devices
                     Skipped due to failed checks: IOMMU
             """
         )

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -3257,7 +3257,7 @@ pci@0000:00:1f.2  docker0     network    Ethernet interface
         assert textwrap.dedent(output) == textwrap.dedent(
             f"""\
             WARN -- PCI devices
-                    IOMMU enabled for vfio-pci, but no network PCI devices found.
+                    No PCI network devices found with IOMMU enabled for vfio-pci.
             """
         )
         assert result is CheckState.WARNING


### PR DESCRIPTION
### Summary
`host-check` checks that there are PCI devices available in the IOMMU check, but IOMMU is only relevant for `vfio-pci`, not `igb_uio`. Should separate the checks for PCI devices from the IOMMU check.

New check setup:
* `check_iommu()`: keeps existing checks for IOMMU but no longer looks for PCI devices.
* `check_pci_devices()`:
    *  If IOMMU is enabled, checks that IOMMU PCI devices are available.
    *  If IOMMU is not enabled, checks that any PCI devices are available.

Testing: existing tests for IOMMU split between new IOMMU and PCI devices checks. 

### Checklist

<!-- See CONTRIBUTING.md. -->

- [ ] Changelog updated (or not required)
  <!-- Is there any reason a user might care about the change?
       Have you changed any files that go in the release tarball?
       New GH release must be created after merging if new version added to the changelog. 
  -->
- [ ] Static analysis and tests passing
   - Use `commit-check` script, or check GitHub Actions status.
