### PR TITLE
Add custom behaviour if OS is Amazon Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ The v1 release supports Cisco IOS-XR release versions 7.7.1 and above.
 
 ### v1.1.18 (2024-12-17)
 
-- Added detection of Amazon Linux 2023 host OS.
-- Added additional checks of cmdline arguments when on Amazon Linux 2023
+- Added detection of Amazon Linux host OS.
+- Added additional checks of cmdline arguments when on Amazon Linux
 - Cgroups v2 is now supported
 
 ### v1.1.17 (2024-06-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 The v1 release supports Cisco IOS-XR release versions 7.7.1 and above.
 
+### v1.1.18 (2024-12-17)
+
+- Added detection of Amazon Linux 2023 host OS.
+- Added additional checks of cmdline arguments when on Amazon Linux 2023
+- Cgroups v2 is now supported
+
 ### v1.1.17 (2024-06-11)
 
 - Fixed entry-point in `host-check` Dockerfile.

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -40,6 +40,7 @@ import enum
 import functools
 import glob
 import os
+from pathlib import Path
 import re
 import shlex
 import subprocess
@@ -97,6 +98,8 @@ BOLD_STYLE = 1
 
 REQUIRED_CGROUP_MOUNTS = ["systemd", "memory", "pids", "cpu", "cpuset"]
 
+AMAZON_LINUX_CPE_RGX = r"^cpe:.*:o:amazon:amazon_linux:2023"
+
 DASHED_LINE = "----------------------------------------------------------------------------"
 DOUBLE_DASHED_LINE = "============================================================================"
 
@@ -111,6 +114,9 @@ MODULE_EXPECTED_PARAMS = {
         "intr_mode": ["msix", "(null)"],
     },
 }
+
+# Global variable for caching result of check of base OS for AL 2023.
+is_al2023 = None
 
 # -----------------------------------------------------------------------------
 # Colours
@@ -314,6 +320,23 @@ def _get_cgroup_version() -> int:
         raise Exception("Unable to detect cgroup version in use")
 
 
+def _is_al2023() -> bool:
+    """Detect if the host is running Amazon Linux 2023."""
+    global is_al2023
+
+    if is_al2023 is not None:
+        return is_al2023
+
+    cpe_path = Path("/etc/system-release-cpe")
+    is_al2023 = False
+    if cpe_path.exists():
+        cpe = cpe_path.read_text().strip()
+        if re.match(AMAZON_LINUX_CPE_RGX, cpe):
+            is_al2023 = True
+
+    return is_al2023
+
+
 # -----------------------------------------------------------------------------
 # Checks
 # -----------------------------------------------------------------------------
@@ -476,30 +499,27 @@ def check_cgroups() -> CheckFuncReturn:
             "contain cgroup v1 mounts.",
         )
 
-    if version == 2:
-        return (
-            CheckState.NEUTRAL,
-            "Cgroups v2 is in use - this is not supported for production environments.",
-        )
-    assert version == 1
+    assert version == 1 or version == 2
 
-    not_exist_mounts = [
-        cgrp_dir
-        for cgrp_dir in REQUIRED_CGROUP_MOUNTS
-        if not _mount_exists(f"/sys/fs/cgroup/{cgrp_dir}", type_="cgroup")
-    ]
-    if not_exist_mounts:
-        fail_msg = (
-            f"These cgroup mounts do not exist on the host: {', '.join(not_exist_mounts)}."
-            "\nThese mounts are required to run XRd."
-        )
-        if "systemd" in not_exist_mounts:
-            fail_msg += (
-                "\nIf your distro doesn't use systemd, manually add the systemd cgroup mount with:"
-                "\n    sudo mkdir /sys/fs/cgroup/systemd"
-                "\n    sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd"
+    if version == 1:
+        not_exist_mounts = [
+            cgrp_dir
+            for cgrp_dir in REQUIRED_CGROUP_MOUNTS
+            if not _mount_exists(f"/sys/fs/cgroup/{cgrp_dir}", type_="cgroup")
+        ]
+        if not_exist_mounts:
+            fail_msg = (
+                f"These cgroup mounts do not exist on the host: {', '.join(not_exist_mounts)}."
+                "\nThese mounts are required to run XRd."
             )
-        return CheckState.FAILED, fail_msg
+            if "systemd" in not_exist_mounts:
+                fail_msg += (
+                    "\nIf your distro doesn't use systemd, manually add the systemd cgroup mount with:"
+                    "\n    sudo mkdir /sys/fs/cgroup/systemd"
+                    "\n    sudo mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd"
+                )
+            return CheckState.FAILED, fail_msg
+
     return CheckState.SUCCESS, f"v{version}"
 
 
@@ -1033,6 +1053,21 @@ def check_interface_kernel_driver() -> CheckFuncReturn:
     installed_not_supported_str = ", ".join(
         driver.name for driver in installed_not_supported
     )
+    # In AWS, must have igb_uio driver available
+    if _is_al2023():
+        if PCIDriver("igb_uio").is_supported():
+            return CheckState.SUCCESS, f"Loaded PCI drivers: {supported_str}"
+        elif PCIDriver("igb_uio").is_installed():
+            return (
+                CheckState.NEUTRAL,
+                "igb_uio driver is installed but not loaded.\n"
+                "Run 'modprobe igb_uio' to load the driver.",
+            )
+        else:
+            return (
+                CheckState.FAILED,
+                "The igb_uio PCI driver is not loaded or installed.",
+            )
     if supported_drivers:
         if installed_not_supported:
             return (
@@ -1064,6 +1099,14 @@ def check_iommu() -> CheckFuncReturn:
     """Check IOMMU is set up correctly for the vfio-pci kernel module."""
     if not PCIDriver("vfio-pci").is_supported():
         return CheckState.NEUTRAL, "vfio-pci driver unavailable"
+
+    # In AWS unconditonally succeed as IOMMU cannot be supported.
+    if _is_al2023():
+        return (
+            CheckState.SUCCESS,
+            "IOMMU not supported in AWS. It is recommended to use the igb_uio "
+            "driver.",
+        )
 
     # If igb_uio is supported, treat warnings as info, because even though
     # IOMMU isn't enabled, igb_uio can be used.
@@ -1495,6 +1538,118 @@ def check_bridge_iptables() -> CheckFuncReturn:
     return CheckState.SUCCESS, "disabled"
 
 
+# -------------------------------------
+# Docker checks
+# -------------------------------------
+
+
+
+
+def check_aws_cmdline() -> CheckFuncReturn:
+    """Check that the expected args are in the cmdline."""
+
+    # Expected values are as set during AMI creation by the XRd packer tool.
+    # See https://github.com/ios-xr/xrd-packer
+
+    cmdline_args = {
+        k: v
+        for k, _, v in (
+            x.partition("=")
+            for x in Path("/proc/cmdline").read_text().strip().split()
+        )
+    }
+
+    # Check the args with known expected values
+    expected_arg_values = {
+        "nohz": "on",
+        "skew_tick": "1",
+        "intel_pstate": "disable",
+        "tsc": "reliable",
+        "nosoftlockup": "",
+        "hugepagesz": "1G",
+        "default_hugepagesz": "1G",
+        "rcupdate.rcu_normal_after_boot": "1",
+    }
+    for arg, expected_value in expected_arg_values.items():
+        if arg not in cmdline_args:
+            return (
+                CheckState.FAILED,
+                f"Expected arg {arg} not found in cmdline",
+            )
+        if expected_value and cmdline_args[arg] != expected_value:
+            return (
+                CheckState.FAILED,
+                f"Expected arg {arg} to be {expected_value} but found "
+                f"{cmdline_args[arg]}",
+            )
+
+    # Check isolated cores-related args
+    for arg in ["nohz_full", "isolcpus", "rcu_nocbs"]:
+        if arg not in cmdline_args:
+            return (
+                CheckState.FAILED,
+                f"Expected arg {arg} not found in cmdline",
+            )
+    if (
+        cmdline_args["nohz_full"] != cmdline_args["isolcpus"]
+        or cmdline_args["nohz_full"] != cmdline_args["rcu_nocbs"]
+        or cmdline_args["isolcpus"] != cmdline_args["rcu_nocbs"]
+    ):
+        return (
+            CheckState.FAILED,
+            "Expected nohz_full, isolcpus and rcu_nocbs to all be the same, "
+            f"but found nohz_full={cmdline_args['nohz_full']}, isolcpus="
+            f"{cmdline_args['isolcpus']}, rcu_nocbs="
+            f"{cmdline_args['rcu_nocbs']}",
+        )
+
+    # Check other args with unknown expected values
+    for arg in ["irqaffinity", "hugepages"]:
+        if arg not in cmdline_args:
+            return (
+                CheckState.FAILED,
+                f"Expected arg {arg} not found in cmdline",
+            )
+
+    # Check the isolated and irqaffinity cores do not overlap
+    isolated_with_range = cmdline_args["isolcpus"].split(",")
+    isolated_cores = set()
+    for c in isolated_with_range:
+        if "-" in c:
+            start, end = c.split("-")
+            for i in range(int(start), int(end) + 1):
+                isolated_cores.add(i)
+        else:
+            isolated_cores.add(int(c))
+    irqaffinity_with_range = cmdline_args["irqaffinity"].split(",")
+    irqaffinity = set()
+    for c in irqaffinity_with_range:
+        if "-" in c:
+            start, end = c.split("-")
+            for i in range(int(start), int(end) + 1):
+                irqaffinity.add(i)
+        else:
+            irqaffinity.add(int(c))
+    if isolated_cores & irqaffinity:
+        return (
+            CheckState.FAILED,
+            f"isolcpus {cmdline_args['isolcpus']} overlap with irqaffinity"
+            f"cores {cmdline_args['irqaffinity']}",
+        )
+
+    if len(isolated_cores) < MIN_CPU_CORES_AVAILABLE:
+        return (
+            CheckState.FAILED,
+            "At least 2 isolated cores are required",
+        )
+
+    return (
+        CheckState.SUCCESS,
+        "Expected cmdline args found with isolated cores "
+        f"{cmdline_args['isolcpus']}",
+    )
+
+
 class Check(NamedTuple):
     """A check for some host capability."""
 
@@ -1560,6 +1715,12 @@ XR_COMPOSE_CHECKS = [
     Check("Bridge iptables", check_bridge_iptables, []),
 ]
 
+CONTROL_PLANE_AWS_CHECKS = []
+
+VROUTER_AWS_CHECKS = [
+    Check("Cmdline arguments", check_aws_cmdline, []),
+]
+
 PLATFORM_CHECKS_MAP: Mapping[str, List[Check]] = {
     "xrd-control-plane": CONTROL_PLANE_CHECKS,
     "xrd-vrouter": VROUTER_CHECKS,
@@ -1567,6 +1728,10 @@ PLATFORM_CHECKS_MAP: Mapping[str, List[Check]] = {
 EXTRA_CHECKS_MAP: Mapping[str, List[Check]] = {
     "docker": DOCKER_CHECKS,
     "xr-compose": XR_COMPOSE_CHECKS,
+}
+PLATFORM_AWS_CHECKS_MAP: Mapping[str, List[Check]] = {
+    "xrd-control-plane": CONTROL_PLANE_AWS_CHECKS,
+    "xrd-vrouter": VROUTER_AWS_CHECKS,
 }
 
 # -----------------------------------------------------------------------------
@@ -1736,6 +1901,11 @@ def run_checks_specific_platform(
 
     print_heading(f"Platform checks - {platform}")
     plat_results = perform_checks(BASE_CHECKS + PLATFORM_CHECKS_MAP[platform])
+    # If AL2023 is detected, run AWS host checks
+    if _is_al2023() and len(PLATFORM_AWS_CHECKS_MAP[platform]) > 0:
+        print_subheading("AWS host checks")
+        al2023_results = perform_checks(PLATFORM_AWS_CHECKS_MAP[platform])
+        plat_results.update(al2023_results)
     plat_failure = any(check.is_failure() for check in plat_results.values())
     plat_error = any(c is CheckState.ERROR for c in plat_results.values())
     plat_warning = any(c is CheckState.WARNING for c in plat_results.values())
@@ -1795,6 +1965,11 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
     for platform, checks in PLATFORM_CHECKS_MAP.items():
         print_subheading(f"{platform} checks")
         plat_results = perform_checks(checks)
+        # If AL2023 is detected, run AWS host checks
+        if _is_al2023() and len(PLATFORM_AWS_CHECKS_MAP[platform]) > 0:
+            print_subheading(f"AWS host checks for {platform}")
+            al2023_results = perform_checks(PLATFORM_AWS_CHECKS_MAP[platform])
+            plat_results.update(al2023_results)
         base_and_plat_results = list(base_results.values()) + list(
             plat_results.values()
         )

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -330,7 +330,7 @@ def _is_al2023() -> bool:
     cpe_path = Path("/etc/system-release-cpe")
     is_al2023 = False
     if cpe_path.exists():
-        cpe = cpe_path.read_text().strip()
+        cpe = cpe_path.read_text(encoding="utf-8").strip()
         if re.match(AMAZON_LINUX_CPE_RGX, cpe):
             is_al2023 = True
 
@@ -499,7 +499,7 @@ def check_cgroups() -> CheckFuncReturn:
             "contain cgroup v1 mounts.",
         )
 
-    assert version == 1 or version == 2
+    assert version in (1, 2)
 
     if version == 1:
         not_exist_mounts = [
@@ -1549,7 +1549,7 @@ def check_aws_cmdline() -> CheckFuncReturn:
     # Expected values are as set during AMI creation by the XRd packer tool.
     # See https://github.com/ios-xr/xrd-packer
 
-    with open("/proc/cmdline", "r") as f:
+    with open("/proc/cmdline", "r", encoding="utf-8") as f:
         cmdline = f.read().strip().split()
 
     cmdline_args = {k: v for k, _, v in (x.partition("=") for x in cmdline)}
@@ -1711,7 +1711,7 @@ XR_COMPOSE_CHECKS = [
     Check("Bridge iptables", check_bridge_iptables, []),
 ]
 
-CONTROL_PLANE_AWS_CHECKS = []
+CONTROL_PLANE_AWS_CHECKS: List[Check] = []
 
 VROUTER_AWS_CHECKS = [
     Check("Cmdline arguments", check_aws_cmdline, []),
@@ -1896,17 +1896,19 @@ def run_checks_specific_platform(
     """
 
     print_heading(f"Platform checks - {platform}")
-    plat_results = perform_checks(BASE_CHECKS + PLATFORM_CHECKS_MAP[platform])
+    plat_results = list(
+        perform_checks(BASE_CHECKS + PLATFORM_CHECKS_MAP[platform]).values(),
+    )
     # If AL2023 is detected, run AWS host checks
     if _is_al2023() and len(PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]) > 0:
         print_subheading("AWS host checks")
         al2023_results = perform_checks(
             PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]
         )
-        plat_results.update(al2023_results)
-    plat_failure = any(check.is_failure() for check in plat_results.values())
-    plat_error = any(c is CheckState.ERROR for c in plat_results.values())
-    plat_warning = any(c is CheckState.WARNING for c in plat_results.values())
+        plat_results += list(al2023_results.values())
+    plat_failure = any(check.is_failure() for check in plat_results)
+    plat_error = any(c is CheckState.ERROR for c in plat_results)
+    plat_warning = any(c is CheckState.WARNING for c in plat_results)
 
     extra_results = run_if_extra_checks(extra_checks)
 
@@ -1963,6 +1965,9 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
     for platform, checks in PLATFORM_CHECKS_MAP.items():
         print_subheading(f"{platform} checks")
         plat_results = perform_checks(checks)
+        base_and_plat_results = list(base_results.values()) + list(
+            plat_results.values()
+        )
         # If AL2023 is detected, run AWS host checks
         if (
             _is_al2023()
@@ -1972,10 +1977,7 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
             al2023_results = perform_checks(
                 PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]
             )
-            plat_results.update(al2023_results)
-        base_and_plat_results = list(base_results.values()) + list(
-            plat_results.values()
-        )
+            base_and_plat_results += list(al2023_results.values())
         if any(result.is_failure() for result in base_and_plat_results):
             platforms_not_supported.add(platform)
         elif any(

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1559,7 +1559,6 @@ def check_aws_cmdline() -> CheckFuncReturn:
         "nosoftlockup": "",
         "hugepagesz": "1G",
         "default_hugepagesz": "1G",
-        "rcupdate.rcu_normal_after_boot": "1",
     }
     for arg, expected_value in expected_arg_values.items():
         if arg not in cmdline_args:

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -40,12 +40,12 @@ import enum
 import functools
 import glob
 import os
-from pathlib import Path
 import re
 import shlex
 import subprocess
 import textwrap
 from dataclasses import dataclass
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -1055,9 +1055,9 @@ def check_interface_kernel_driver() -> CheckFuncReturn:
     )
     # In AWS, must have igb_uio driver available
     if _is_al2023():
-        if PCIDriver("igb_uio").is_supported():
+        if "igb_uio" in supported_str:
             return CheckState.SUCCESS, f"Loaded PCI drivers: {supported_str}"
-        elif PCIDriver("igb_uio").is_installed():
+        elif "igb_uio" in installed_not_supported_str:
             return (
                 CheckState.NEUTRAL,
                 "igb_uio driver is installed but not loaded.\n"
@@ -1103,7 +1103,7 @@ def check_iommu() -> CheckFuncReturn:
     # In AWS unconditonally succeed as IOMMU cannot be supported.
     if _is_al2023():
         return (
-            CheckState.SUCCESS,
+            CheckState.NEUTRAL,
             "IOMMU not supported in AWS. It is recommended to use the igb_uio "
             "driver.",
         )
@@ -1539,10 +1539,8 @@ def check_bridge_iptables() -> CheckFuncReturn:
 
 
 # -------------------------------------
-# Docker checks
+# AWS checks
 # -------------------------------------
-
-
 
 
 def check_aws_cmdline() -> CheckFuncReturn:
@@ -1551,13 +1549,10 @@ def check_aws_cmdline() -> CheckFuncReturn:
     # Expected values are as set during AMI creation by the XRd packer tool.
     # See https://github.com/ios-xr/xrd-packer
 
-    cmdline_args = {
-        k: v
-        for k, _, v in (
-            x.partition("=")
-            for x in Path("/proc/cmdline").read_text().strip().split()
-        )
-    }
+    with open("/proc/cmdline", "r") as f:
+        cmdline = f.read().strip().split()
+
+    cmdline_args = {k: v for k, _, v in (x.partition("=") for x in cmdline)}
 
     # Check the args with known expected values
     expected_arg_values = {
@@ -1633,8 +1628,9 @@ def check_aws_cmdline() -> CheckFuncReturn:
     if isolated_cores & irqaffinity:
         return (
             CheckState.FAILED,
-            f"isolcpus {cmdline_args['isolcpus']} overlap with irqaffinity"
-            f"cores {cmdline_args['irqaffinity']}",
+            "Expected isolcpus and irqaffinity to be disjoint, but found "
+            f"isolcpus={cmdline_args['isolcpus']} and "
+            f"irqaffinity={cmdline_args['irqaffinity']}",
         )
 
     if len(isolated_cores) < MIN_CPU_CORES_AVAILABLE:
@@ -1730,8 +1726,8 @@ EXTRA_CHECKS_MAP: Mapping[str, List[Check]] = {
     "xr-compose": XR_COMPOSE_CHECKS,
 }
 PLATFORM_AWS_CHECKS_MAP: Mapping[str, List[Check]] = {
-    "xrd-control-plane": CONTROL_PLANE_AWS_CHECKS,
-    "xrd-vrouter": VROUTER_AWS_CHECKS,
+    "xrd-control-plane-aws": CONTROL_PLANE_AWS_CHECKS,
+    "xrd-vrouter-aws": VROUTER_AWS_CHECKS,
 }
 
 # -----------------------------------------------------------------------------
@@ -1902,9 +1898,11 @@ def run_checks_specific_platform(
     print_heading(f"Platform checks - {platform}")
     plat_results = perform_checks(BASE_CHECKS + PLATFORM_CHECKS_MAP[platform])
     # If AL2023 is detected, run AWS host checks
-    if _is_al2023() and len(PLATFORM_AWS_CHECKS_MAP[platform]) > 0:
+    if _is_al2023() and len(PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]) > 0:
         print_subheading("AWS host checks")
-        al2023_results = perform_checks(PLATFORM_AWS_CHECKS_MAP[platform])
+        al2023_results = perform_checks(
+            PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]
+        )
         plat_results.update(al2023_results)
     plat_failure = any(check.is_failure() for check in plat_results.values())
     plat_error = any(c is CheckState.ERROR for c in plat_results.values())
@@ -1966,9 +1964,14 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
         print_subheading(f"{platform} checks")
         plat_results = perform_checks(checks)
         # If AL2023 is detected, run AWS host checks
-        if _is_al2023() and len(PLATFORM_AWS_CHECKS_MAP[platform]) > 0:
+        if (
+            _is_al2023()
+            and len(PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]) > 0
+        ):
             print_subheading(f"AWS host checks for {platform}")
-            al2023_results = perform_checks(PLATFORM_AWS_CHECKS_MAP[platform])
+            al2023_results = perform_checks(
+                PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]
+            )
             plat_results.update(al2023_results)
         base_and_plat_results = list(base_results.values()) + list(
             plat_results.values()

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -116,7 +116,7 @@ MODULE_EXPECTED_PARAMS = {
 }
 
 # Global variable for caching result of check of base OS for AL 2023.
-is_al2023 = None
+_is_al2023_cache = None
 
 # -----------------------------------------------------------------------------
 # Colours
@@ -320,21 +320,21 @@ def _get_cgroup_version() -> int:
         raise Exception("Unable to detect cgroup version in use")
 
 
-def _is_al2023() -> bool:
+def is_al2023() -> bool:
     """Detect if the host is running Amazon Linux 2023."""
-    global is_al2023
+    global _is_al2023_cache
 
-    if is_al2023 is not None:
-        return is_al2023
+    if _is_al2023_cache is not None:
+        return _is_al2023_cache
 
     cpe_path = Path("/etc/system-release-cpe")
-    is_al2023 = False
+    _is_al2023_cache = False
     if cpe_path.exists():
         cpe = cpe_path.read_text(encoding="utf-8").strip()
         if re.match(AMAZON_LINUX_CPE_RGX, cpe):
-            is_al2023 = True
+            _is_al2023_cache = True
 
-    return is_al2023
+    return _is_al2023_cache
 
 
 # -----------------------------------------------------------------------------
@@ -1054,7 +1054,7 @@ def check_interface_kernel_driver() -> CheckFuncReturn:
         driver.name for driver in installed_not_supported
     )
     # In AWS, must have igb_uio driver available
-    if _is_al2023():
+    if is_al2023():
         if "igb_uio" in supported_str:
             return CheckState.SUCCESS, f"Loaded PCI drivers: {supported_str}"
         elif "igb_uio" in installed_not_supported_str:
@@ -1101,12 +1101,8 @@ def check_iommu() -> CheckFuncReturn:
         return CheckState.NEUTRAL, "vfio-pci driver unavailable"
 
     # In AWS unconditonally succeed as IOMMU cannot be supported.
-    if _is_al2023():
-        return (
-            CheckState.NEUTRAL,
-            "IOMMU not supported in AWS. It is recommended to use the igb_uio "
-            "driver.",
-        )
+    if is_al2023():
+        return CheckState.NEUTRAL, "IOMMU is not supported in AWS."
 
     # If igb_uio is supported, treat warnings as info, because even though
     # IOMMU isn't enabled, igb_uio can be used.
@@ -1900,7 +1896,7 @@ def run_checks_specific_platform(
         perform_checks(BASE_CHECKS + PLATFORM_CHECKS_MAP[platform]).values(),
     )
     # If AL2023 is detected, run AWS host checks
-    if _is_al2023() and len(PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]) > 0:
+    if is_al2023() and PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]:
         print_subheading("AWS host checks")
         al2023_results = perform_checks(
             PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]
@@ -1969,10 +1965,7 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
             plat_results.values()
         )
         # If AL2023 is detected, run AWS host checks
-        if (
-            _is_al2023()
-            and len(PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]) > 0
-        ):
+        if is_al2023() and PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]:
             print_subheading(f"AWS host checks for {platform}")
             al2023_results = perform_checks(
                 PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1897,9 +1897,7 @@ def run_checks_specific_platform(
     # If Amazon Linux is detected, run AWS host checks
     if is_amazon_linux() and PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]:
         print_subheading("AWS host checks")
-        al_results = perform_checks(
-            PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]
-        )
+        al_results = perform_checks(PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"])
         plat_results += list(al_results.values())
     plat_failure = any(check.is_failure() for check in plat_results)
     plat_error = any(c is CheckState.ERROR for c in plat_results)

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -98,7 +98,7 @@ BOLD_STYLE = 1
 
 REQUIRED_CGROUP_MOUNTS = ["systemd", "memory", "pids", "cpu", "cpuset"]
 
-AMAZON_LINUX_CPE_RGX = r"^cpe:.*:o:amazon:amazon_linux:2023"
+AMAZON_LINUX_CPE_RGX = r"^cpe:.*:o:amazon:amazon_linux"
 
 DASHED_LINE = "----------------------------------------------------------------------------"
 DOUBLE_DASHED_LINE = "============================================================================"
@@ -115,8 +115,8 @@ MODULE_EXPECTED_PARAMS = {
     },
 }
 
-# Global variable for caching result of check of base OS for AL 2023.
-_is_al2023_cache = None
+# Global variable for caching result of check of base OS for Amazon Linux.
+_is_amazon_linux_cache = None
 
 # -----------------------------------------------------------------------------
 # Colours
@@ -320,21 +320,21 @@ def _get_cgroup_version() -> int:
         raise Exception("Unable to detect cgroup version in use")
 
 
-def is_al2023() -> bool:
-    """Detect if the host is running Amazon Linux 2023."""
-    global _is_al2023_cache
+def is_amazon_linux() -> bool:
+    """Detect if the host is running Amazon Linux."""
+    global _is_amazon_linux_cache
 
-    if _is_al2023_cache is not None:
-        return _is_al2023_cache
+    if _is_amazon_linux_cache is not None:
+        return _is_amazon_linux_cache
 
     cpe_path = Path("/etc/system-release-cpe")
-    _is_al2023_cache = False
+    _is_amazon_linux_cache = False
     if cpe_path.exists():
         cpe = cpe_path.read_text(encoding="utf-8").strip()
         if re.match(AMAZON_LINUX_CPE_RGX, cpe):
-            _is_al2023_cache = True
+            _is_amazon_linux_cache = True
 
-    return _is_al2023_cache
+    return _is_amazon_linux_cache
 
 
 # -----------------------------------------------------------------------------
@@ -1054,7 +1054,7 @@ def check_interface_kernel_driver() -> CheckFuncReturn:
         driver.name for driver in installed_not_supported
     )
     # In AWS, must have igb_uio driver available
-    if is_al2023():
+    if is_amazon_linux():
         if "igb_uio" in supported_str:
             return CheckState.SUCCESS, f"Loaded PCI drivers: {supported_str}"
         elif "igb_uio" in installed_not_supported_str:
@@ -1101,7 +1101,7 @@ def check_iommu() -> CheckFuncReturn:
         return CheckState.NEUTRAL, "vfio-pci driver unavailable"
 
     # In AWS unconditonally succeed as IOMMU cannot be supported.
-    if is_al2023():
+    if is_amazon_linux():
         return CheckState.NEUTRAL, "IOMMU is not supported in AWS."
 
     # If igb_uio is supported, treat warnings as info, because even though
@@ -1895,8 +1895,8 @@ def run_checks_specific_platform(
     plat_results = list(
         perform_checks(BASE_CHECKS + PLATFORM_CHECKS_MAP[platform]).values(),
     )
-    # If AL2023 is detected, run AWS host checks
-    if is_al2023() and PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]:
+    # If Amazon Linux is detected, run AWS host checks
+    if is_amazon_linux() and PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]:
         print_subheading("AWS host checks")
         al2023_results = perform_checks(
             PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]
@@ -1965,7 +1965,7 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
             plat_results.values()
         )
         # If AL2023 is detected, run AWS host checks
-        if is_al2023() and PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]:
+        if is_amazon_linux() and PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]:
             print_subheading(f"AWS host checks for {platform}")
             al2023_results = perform_checks(
                 PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]

--- a/scripts/host-check
+++ b/scripts/host-check
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2020-2023 Cisco Systems Inc.
+# Copyright 2020-2024 Cisco Systems Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1897,10 +1897,10 @@ def run_checks_specific_platform(
     # If Amazon Linux is detected, run AWS host checks
     if is_amazon_linux() and PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]:
         print_subheading("AWS host checks")
-        al2023_results = perform_checks(
+        al_results = perform_checks(
             PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]
         )
-        plat_results += list(al2023_results.values())
+        plat_results += list(al_results.values())
     plat_failure = any(check.is_failure() for check in plat_results)
     plat_error = any(c is CheckState.ERROR for c in plat_results)
     plat_warning = any(c is CheckState.WARNING for c in plat_results)
@@ -1963,13 +1963,13 @@ def run_checks_all_platforms(extra_checks: List[str]) -> int:
         base_and_plat_results = list(base_results.values()) + list(
             plat_results.values()
         )
-        # If AL2023 is detected, run AWS host checks
+        # If Amazon Linux is detected, run AWS host checks
         if is_amazon_linux() and PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]:
             print_subheading(f"AWS host checks for {platform}")
-            al2023_results = perform_checks(
+            al_results = perform_checks(
                 PLATFORM_AWS_CHECKS_MAP[f"{platform}-aws"]
             )
-            base_and_plat_results += list(al2023_results.values())
+            base_and_plat_results += list(al_results.values())
         if any(result.is_failure() for result in base_and_plat_results):
             platforms_not_supported.add(platform)
         elif any(

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -4058,7 +4058,6 @@ class TestAwsCmdline(_CheckTestBase):
             "rcu_nocbs": "2-3",
             "hugepagesz": "1G",
             "default_hugepagesz": "1G",
-            "rcupdate.rcu_normal_after_boot": "1",
         }
 
         def __init__(
@@ -4103,7 +4102,6 @@ class TestAwsCmdline(_CheckTestBase):
             ("tsc", "unreliable", "reliable"),
             ("hugepagesz", "2M", "1G"),
             ("default_hugepagesz", "2M", "1G"),
-            ("rcupdate.rcu_normal_after_boot", "0", "1"),
         ],
     )
     def test_wrong_arg_values(
@@ -4142,7 +4140,6 @@ class TestAwsCmdline(_CheckTestBase):
             "tsc",
             "hugepagesz",
             "default_hugepagesz",
-            "rcupdate.rcu_normal_after_boot",
         ],
     )
     def test_missing_values(self, capsys, is_amazon_linux, arg):

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -44,6 +44,7 @@ CHECKS_BY_GROUP = {
     "base": host_check.BASE_CHECKS,
     **host_check.PLATFORM_CHECKS_MAP,
     **host_check.EXTRA_CHECKS_MAP,
+    **host_check.PLATFORM_AWS_CHECKS_MAP,
 }
 
 
@@ -182,6 +183,27 @@ def perform_check(
     return result, output
 
 
+@pytest.fixture(autouse=True)
+def is_not_al2023(request):
+    """Mock the is_al2023() function to return False."""
+    # Don't mock _is_al2023() function if the test is marked
+    if "no_is_al2023_mock" in request.keywords:
+        yield None
+    else:
+        with mock.patch("host_check._is_al2023") as f:
+            f.return_value = False
+            yield f
+
+
+@pytest.fixture()
+def is_al2023():
+    """Mock the is_al2023() function to return True."""
+    # When used, this fixture superceeds the mock_is_al2023_false fixture.
+    with mock.patch("host_check._is_al2023") as f:
+        f.return_value = True
+        yield f
+
+
 # ------------------------------------------------------------------------------
 # Tests
 # ------------------------------------------------------------------------------
@@ -249,6 +271,37 @@ XR platforms supported: xrd-control-plane, xrd-vrouter
         assert output == cli_output
         assert exit_code == EXIT_SUCCESS
 
+    def test_no_args_aws(self, capsys, is_al2023):
+        """Test running host-check with no arguments in AWS."""
+        exit_code, output = self.run_host_check(capsys, [])
+        cli_output = f"""\
+==============================
+Platform checks
+==============================
+
+base checks
+-----------------------
+Checks: {BASE_CHECKS_STR}
+
+xrd-control-plane checks
+-----------------------
+Checks: {CONTROL_PLANE_CHECKS_STR}
+
+xrd-vrouter checks
+-----------------------
+Checks: {VROUTER_CHECKS_STR}
+
+AWS host checks for xrd-vrouter
+-----------------------
+Checks: Cmdline arguments
+
+============================================================================
+XR platforms supported: xrd-control-plane, xrd-vrouter
+============================================================================
+"""
+        assert output == cli_output
+        assert exit_code == EXIT_SUCCESS
+
     def test_plat_xrd(self, capsys):
         """Test running host-check with the xrd CP platform argument."""
         exit_code, output = self.run_host_check(
@@ -275,6 +328,47 @@ Host environment set up correctly for xrd-control-plane
 Platform checks - xrd-vrouter
 ==============================
 Checks: {BASE_CHECKS_STR}, {VROUTER_CHECKS_STR}
+
+============================================================================
+Host environment set up correctly for xrd-vrouter
+============================================================================
+"""
+        assert output == cli_output
+        assert exit_code == EXIT_SUCCESS
+
+    def test_plat_xrd_aws(self, capsys, is_al2023):
+        """Test running host-check with the xrd CP platform argument in AWS."""
+        exit_code, output = self.run_host_check(
+            capsys, ["-p", "xrd-control-plane"]
+        )
+        cli_output = f"""\
+==============================
+Platform checks - xrd-control-plane
+==============================
+Checks: {BASE_CHECKS_STR}, {CONTROL_PLANE_CHECKS_STR}
+
+============================================================================
+Host environment set up correctly for xrd-control-plane
+============================================================================
+"""
+        assert output == cli_output
+        assert exit_code == EXIT_SUCCESS
+
+    def test_plat_xrd_vrouter_aws(self, capsys, is_al2023):
+        """
+        Test running host-check with the xrd-vrouter platform argument in AWS.
+
+        """
+        exit_code, output = self.run_host_check(capsys, ["-p", "xrd-vrouter"])
+        cli_output = f"""\
+==============================
+Platform checks - xrd-vrouter
+==============================
+Checks: {BASE_CHECKS_STR}, {VROUTER_CHECKS_STR}
+
+AWS host checks
+-----------------------
+Checks: Cmdline arguments
 
 ============================================================================
 Host environment set up correctly for xrd-vrouter
@@ -1437,7 +1531,7 @@ class TestCgroups(_CheckTestBase):
         )
         assert result is CheckState.ERROR
 
-    def test_v2_info(self, capsys):
+    def test_v2_success(self, capsys):
         """Test the case where v2 cgroups are in use."""
         with mock.patch("builtins.open", mock.mock_open(read_data="memory")):
             result, output = self.perform_check(
@@ -1445,11 +1539,10 @@ class TestCgroups(_CheckTestBase):
             )
         assert textwrap.dedent(output) == textwrap.dedent(
             """\
-            INFO -- Cgroups
-                    Cgroups v2 is in use - this is not supported for production environments.
+            PASS -- Cgroups (v2)
             """
         )
-        assert result is CheckState.NEUTRAL
+        assert result is CheckState.SUCCESS
 
     def test_subproc_error(self, capsys):
         """Test a subprocess error being raised."""
@@ -2941,6 +3034,72 @@ class TestGDPKernelDriver(_CheckTestBase):
         )
         assert result is CheckState.ERROR
 
+    def test_aws_igb_uio(self, capsys, is_al2023):
+        """Test the case in AWS where the igb_uio driver is present."""
+        # Command (grep -q) simply returns 0.
+        result, output = self.perform_check(
+            capsys,
+            cmd_effects=[
+                subprocess.CalledProcessError(1, ""),
+                subprocess.CalledProcessError(1, ""),
+                "",
+                None,
+                subprocess.CalledProcessError(1, ""),
+                None,
+            ],
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            f"""\
+            PASS -- Interface kernel driver (Loaded PCI drivers: igb_uio)
+            """
+        )
+        assert result is CheckState.SUCCESS
+
+    def test_aws_igb_uio_not_loaded(self, capsys, is_al2023):
+        """Test the case in AWS where the igb_uio driver is present."""
+        # Command (grep -q) simply returns 0.
+        result, output = self.perform_check(
+            capsys,
+            cmd_effects=[
+                subprocess.CalledProcessError(1, ""),
+                subprocess.CalledProcessError(1, ""),
+                subprocess.CalledProcessError(1, ""),
+                subprocess.CalledProcessError(1, ""),
+                subprocess.CalledProcessError(1, ""),
+                "",
+            ],
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            f"""\
+            INFO -- Interface kernel driver
+                    igb_uio driver is installed but not loaded.
+                    Run 'modprobe igb_uio' to load the driver.
+            """
+        )
+        assert result is CheckState.NEUTRAL
+
+    def test_aws_igb_uio_missing(self, capsys, is_al2023):
+        """Test the case in AWS where the igb_uio driver is present."""
+        # Command (grep -q) simply returns 0.
+        result, output = self.perform_check(
+            capsys,
+            cmd_effects=[
+                subprocess.CalledProcessError(1, ""),
+                subprocess.CalledProcessError(1, ""),
+                subprocess.CalledProcessError(1, ""),
+                subprocess.CalledProcessError(1, ""),
+                subprocess.CalledProcessError(1, ""),
+                subprocess.CalledProcessError(1, ""),
+            ],
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            f"""\
+            FAIL -- Interface kernel driver
+                    The igb_uio PCI driver is not loaded or installed.
+            """
+        )
+        assert result is CheckState.FAILED
+
 
 class TestIOMMU(_CheckTestBase):
     """Tests for the IOMMU check."""
@@ -3162,6 +3321,20 @@ pci@0000:00:01.0  device2     network    Ethernet interface
             f"""\
             INFO -- IOMMU
                     vfio-pci is set up in no-IOMMU mode, but IOMMU is recommended for security.
+            """
+        )
+        assert result is CheckState.NEUTRAL
+
+    def test_aws(self, capsys, is_al2023):
+        """Test that in AWS the expected info result is seen."""
+        result, output = self.perform_check(
+            capsys,
+            cmd_effects=["", None],
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            f"""\
+            INFO -- IOMMU
+                    IOMMU not supported in AWS. It is recommended to use the igb_uio driver.
             """
         )
         assert result is CheckState.NEUTRAL
@@ -3865,3 +4038,227 @@ class TestBridgeIptables(_CheckTestBase):
             """
         )
         assert result is CheckState.ERROR
+
+
+class TestAwsCmdline(_CheckTestBase):
+    check_group = "xrd-vrouter-aws"
+    check_name = "Cmdline arguments"
+    files = ["/proc/cmdline"]
+
+    class Cmdline:
+        SUCCESS_CMDLINE_OPTS = {
+            "nohz_full": "2-3",
+            "nohz": "on",
+            "skew_tick": "1",
+            "intel_pstate": "disable",
+            "tsc": "reliable",
+            "nosoftlockup": "",
+            "isolcpus": "2-3",
+            "irqaffinity": "0-1",
+            "hugepages": "6",
+            "rcu_nocbs": "2-3",
+            "hugepagesz": "1G",
+            "default_hugepagesz": "1G",
+            "rcupdate.rcu_normal_after_boot": "1",
+        }
+
+        def __init__(
+            self,
+            *,
+            value_override: Optional[Dict[str, str]] = None,
+            missing_flags: Optional[List[str]] = None,
+        ):
+            self.values = self.SUCCESS_CMDLINE_OPTS.copy()
+            if value_override:
+                self.values.update(value_override)
+            if missing_flags:
+                for flag in missing_flags:
+                    del self.values[flag]
+
+        def __str__(self):
+            return " ".join(
+                f"{key}={value}" if value else key
+                for key, value in self.values.items()
+            )
+
+    def test_success(self, capsys, is_al2023):
+        """Test the success case."""
+        result, output = self.perform_check(
+            capsys,
+            read_effects=[str(self.Cmdline())],
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            f"""\
+            PASS -- Cmdline arguments
+                    Expected cmdline args found with isolated cores 2-3
+            """
+        )
+        assert result is CheckState.SUCCESS
+
+    @pytest.mark.parametrize(
+        "arg,value,expected",
+        [
+            ("nohz", "off", "on"),
+            ("skew_tick", "0", "1"),
+            ("intel_pstate", "enable", "disable"),
+            ("tsc", "unreliable", "reliable"),
+            ("hugepagesz", "2M", "1G"),
+            ("default_hugepagesz", "2M", "1G"),
+            ("rcupdate.rcu_normal_after_boot", "0", "1"),
+        ],
+    )
+    def test_wrong_arg_values(self, capsys, is_al2023, arg, value, expected):
+        """
+        Test the failure cases for incorrect arg values.
+
+        Test cases parametrized by the argument name, the wrong value, and the
+        expected value.
+        """
+        cmdline = str(self.Cmdline(value_override={arg: value}))
+        result, output = self.perform_check(
+            capsys,
+            read_effects=[cmdline],
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            f"""\
+            FAIL -- Cmdline arguments
+                    Expected arg {arg} to be {expected} but found {value}
+            """
+        )
+        assert result is CheckState.FAILED
+
+    @pytest.mark.parametrize(
+        "arg",
+        [
+            "nosoftlockup",
+            "isolcpus",
+            "nohz_full",
+            "irqaffinity",
+            "hugepages",
+            "nohz",
+            "skew_tick",
+            "intel_pstate",
+            "tsc",
+            "hugepagesz",
+            "default_hugepagesz",
+            "rcupdate.rcu_normal_after_boot",
+        ],
+    )
+    def test_missing_values(self, capsys, is_al2023, arg):
+        """Test the failure cases for missing arguments."""
+        cmdline = str(self.Cmdline(missing_flags=[arg]))
+        result, output = self.perform_check(
+            capsys,
+            read_effects=[cmdline],
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            f"""\
+            FAIL -- Cmdline arguments
+                    Expected arg {arg} not found in cmdline
+            """
+        )
+        assert result is CheckState.FAILED
+
+    @pytest.mark.parametrize(
+        "arg,value",
+        [
+            ("nohz_full", "0"),
+            ("isolcpus", "0"),
+            ("rcu_nocbs", "0"),
+        ],
+    )
+    def test_non_matching_isolated_cpus(self, capsys, is_al2023, arg, value):
+        """
+        Test the failure case for non-matching isolated CPUs.
+
+        For each of the args that should have isolated CPUs 2-3, test the case
+        where the isolated CPUs are not this.
+        """
+        cmdline = self.Cmdline(value_override={arg: value})
+        result, output = self.perform_check(
+            capsys,
+            read_effects=[str(cmdline)],
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            f"""\
+            FAIL -- Cmdline arguments
+                    Expected nohz_full, isolcpus and rcu_nocbs to all be the same, but found nohz_full={cmdline.values['nohz_full']}, isolcpus={cmdline.values['isolcpus']}, rcu_nocbs={cmdline.values['rcu_nocbs']}
+            """
+        )
+        assert result is CheckState.FAILED
+
+    def test_overlapping_isolcpus_and_irqaffinity(self, capsys, is_al2023):
+        """Test the failure case for overlapping isolcpus and irqaffinity."""
+        cmdline = self.Cmdline(
+            value_override={"isolcpus": "2-3", "irqaffinity": "0-3"}
+        )
+        result, output = self.perform_check(
+            capsys,
+            read_effects=[str(cmdline)],
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            f"""\
+            FAIL -- Cmdline arguments
+                    Expected isolcpus and irqaffinity to be disjoint, but found isolcpus={cmdline.values['isolcpus']} and irqaffinity={cmdline.values['irqaffinity']}
+            """
+        )
+        assert result is CheckState.FAILED
+
+    def test_not_enough_isolated_cores(self, capsys, is_al2023):
+        """Test the failure case for not enough isolated cores."""
+        cmdline = self.Cmdline(
+            value_override={
+                "isolcpus": "2",
+                "nohz_full": "2",
+                "rcu_nocbs": "2",
+            }
+        )
+        result, output = self.perform_check(
+            capsys,
+            read_effects=[str(cmdline)],
+        )
+        assert textwrap.dedent(output) == textwrap.dedent(
+            f"""\
+            FAIL -- Cmdline arguments
+                    At least 2 isolated cores are required
+            """
+        )
+        assert result is CheckState.FAILED
+
+
+class TestIsAL2023:
+    """Class to test the detection of AL2023 operating system."""
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self):
+        host_check.is_al2023 = None
+        yield
+        host_check.is_al2023 = None
+
+    @pytest.mark.no_is_al2023_mock
+    def test_true(self):
+        """Test the case where the CPE file is found and matches AL2023."""
+        with mock.patch("pathlib.Path.exists") as mock_exists:
+            with mock.patch("pathlib.Path.read_text") as mock_read:
+                mock_exists.return_value = True
+                mock_read.return_value = "cpe:2.3:o:cisco:cisco_linux:2023:foo"
+                assert not host_check._is_al2023()
+
+    @pytest.mark.no_is_al2023_mock
+    def test_false(self):
+        """
+        Test the case where the CPE file is found and does not match AL2023.
+
+        """
+        with mock.patch("pathlib.Path.exists") as mock_exists:
+            with mock.patch("pathlib.Path.read_text") as mock_read:
+                mock_exists.return_value = True
+                mock_read.return_value = "cpe:2.3:o:cisco:cisco_linux:2023:foo"
+                assert not host_check._is_al2023()
+
+    @pytest.mark.no_is_al2023_mock
+    def test_not_found(self):
+        """Test the case where the CPE file is not found."""
+        with mock.patch("pathlib.Path.exists") as mock_exists:
+            mock_exists.return_value = False
+            assert not host_check._is_al2023()

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -184,22 +184,22 @@ def perform_check(
 
 
 @pytest.fixture(autouse=True)
-def is_not_al2023(request):
-    """Mock the is_al2023() function to return False."""
-    # Don't mock is_al2023() function if the test is marked
-    if "no_is_al2023_mock" in request.keywords:
+def is_not_amazon_linux(request):
+    """Mock the is_amazon_linux() function to return False."""
+    # Don't mock is_amazon_linux() function if the test is marked
+    if "no_is_amazon_linux_mock" in request.keywords:
         yield None
     else:
-        with mock.patch("host_check.is_al2023") as f:
+        with mock.patch("host_check.is_amazon_linux") as f:
             f.return_value = False
             yield f
 
 
 @pytest.fixture()
-def is_al2023():
-    """Mock the is_al2023() function to return True."""
-    # When used, this fixture superceeds the mock_is_al2023_false fixture.
-    with mock.patch("host_check.is_al2023") as f:
+def is_amazon_linux():
+    """Mock the is_amazon_linux() function to return True."""
+    # When used, this fixture superceeds the mock_is_amazon_linux_false fixture.
+    with mock.patch("host_check.is_amazon_linux") as f:
         f.return_value = True
         yield f
 
@@ -271,7 +271,7 @@ XR platforms supported: xrd-control-plane, xrd-vrouter
         assert output == cli_output
         assert exit_code == EXIT_SUCCESS
 
-    def test_no_args_aws(self, capsys, is_al2023):
+    def test_no_args_aws(self, capsys, is_amazon_linux):
         """Test running host-check with no arguments in AWS."""
         exit_code, output = self.run_host_check(capsys, [])
         cli_output = f"""\
@@ -336,7 +336,7 @@ Host environment set up correctly for xrd-vrouter
         assert output == cli_output
         assert exit_code == EXIT_SUCCESS
 
-    def test_plat_xrd_aws(self, capsys, is_al2023):
+    def test_plat_xrd_aws(self, capsys, is_amazon_linux):
         """Test running host-check with the xrd CP platform argument in AWS."""
         exit_code, output = self.run_host_check(
             capsys, ["-p", "xrd-control-plane"]
@@ -354,7 +354,7 @@ Host environment set up correctly for xrd-control-plane
         assert output == cli_output
         assert exit_code == EXIT_SUCCESS
 
-    def test_plat_xrd_vrouter_aws(self, capsys, is_al2023):
+    def test_plat_xrd_vrouter_aws(self, capsys, is_amazon_linux):
         """
         Test running host-check with the xrd-vrouter platform argument in AWS.
 
@@ -3034,7 +3034,7 @@ class TestGDPKernelDriver(_CheckTestBase):
         )
         assert result is CheckState.ERROR
 
-    def test_aws_igb_uio(self, capsys, is_al2023):
+    def test_aws_igb_uio(self, capsys, is_amazon_linux):
         """Test the case in AWS where the igb_uio driver is present."""
         # Command (grep -q) simply returns 0.
         result, output = self.perform_check(
@@ -3055,7 +3055,7 @@ class TestGDPKernelDriver(_CheckTestBase):
         )
         assert result is CheckState.SUCCESS
 
-    def test_aws_igb_uio_not_loaded(self, capsys, is_al2023):
+    def test_aws_igb_uio_not_loaded(self, capsys, is_amazon_linux):
         """Test the case in AWS where the igb_uio driver is present."""
         # Command (grep -q) simply returns 0.
         result, output = self.perform_check(
@@ -3078,7 +3078,7 @@ class TestGDPKernelDriver(_CheckTestBase):
         )
         assert result is CheckState.NEUTRAL
 
-    def test_aws_igb_uio_missing(self, capsys, is_al2023):
+    def test_aws_igb_uio_missing(self, capsys, is_amazon_linux):
         """Test the case in AWS where the igb_uio driver is present."""
         # Command (grep -q) simply returns 0.
         result, output = self.perform_check(
@@ -3325,7 +3325,7 @@ pci@0000:00:01.0  device2     network    Ethernet interface
         )
         assert result is CheckState.NEUTRAL
 
-    def test_aws(self, capsys, is_al2023):
+    def test_aws(self, capsys, is_amazon_linux):
         """Test that in AWS the expected info result is seen."""
         result, output = self.perform_check(
             capsys,
@@ -4080,7 +4080,7 @@ class TestAwsCmdline(_CheckTestBase):
                 for key, value in self.values.items()
             )
 
-    def test_success(self, capsys, is_al2023):
+    def test_success(self, capsys, is_amazon_linux):
         """Test the success case."""
         result, output = self.perform_check(
             capsys,
@@ -4106,7 +4106,9 @@ class TestAwsCmdline(_CheckTestBase):
             ("rcupdate.rcu_normal_after_boot", "0", "1"),
         ],
     )
-    def test_wrong_arg_values(self, capsys, is_al2023, arg, value, expected):
+    def test_wrong_arg_values(
+        self, capsys, is_amazon_linux, arg, value, expected
+    ):
         """
         Test the failure cases for incorrect arg values.
 
@@ -4143,7 +4145,7 @@ class TestAwsCmdline(_CheckTestBase):
             "rcupdate.rcu_normal_after_boot",
         ],
     )
-    def test_missing_values(self, capsys, is_al2023, arg):
+    def test_missing_values(self, capsys, is_amazon_linux, arg):
         """Test the failure cases for missing arguments."""
         cmdline = str(self.Cmdline(missing_flags=[arg]))
         result, output = self.perform_check(
@@ -4166,7 +4168,9 @@ class TestAwsCmdline(_CheckTestBase):
             ("rcu_nocbs", "0"),
         ],
     )
-    def test_non_matching_isolated_cpus(self, capsys, is_al2023, arg, value):
+    def test_non_matching_isolated_cpus(
+        self, capsys, is_amazon_linux, arg, value
+    ):
         """
         Test the failure case for non-matching isolated CPUs.
 
@@ -4186,7 +4190,9 @@ class TestAwsCmdline(_CheckTestBase):
         )
         assert result is CheckState.FAILED
 
-    def test_overlapping_isolcpus_and_irqaffinity(self, capsys, is_al2023):
+    def test_overlapping_isolcpus_and_irqaffinity(
+        self, capsys, is_amazon_linux
+    ):
         """Test the failure case for overlapping isolcpus and irqaffinity."""
         cmdline = self.Cmdline(
             value_override={"isolcpus": "2-3", "irqaffinity": "0-3"}
@@ -4203,7 +4209,7 @@ class TestAwsCmdline(_CheckTestBase):
         )
         assert result is CheckState.FAILED
 
-    def test_not_enough_isolated_cores(self, capsys, is_al2023):
+    def test_not_enough_isolated_cores(self, capsys, is_amazon_linux):
         """Test the failure case for not enough isolated cores."""
         cmdline = self.Cmdline(
             value_override={
@@ -4230,20 +4236,20 @@ class TestIsAL2023:
 
     @pytest.fixture(autouse=True)
     def cleanup(self):
-        host_check._is_al2023_cache = None
+        host_check._is_amazon_linux_cache = None
         yield
-        host_check._is_al2023_cache = None
+        host_check._is_amazon_linux_cache = None
 
-    @pytest.mark.no_is_al2023_mock
+    @pytest.mark.no_is_amazon_linux_mock
     def test_true(self):
         """Test the case where the CPE file is found and matches AL2023."""
         with mock.patch("pathlib.Path.exists") as mock_exists:
             with mock.patch("pathlib.Path.read_text") as mock_read:
                 mock_exists.return_value = True
                 mock_read.return_value = "cpe:2.3:o:cisco:cisco_linux:2023:foo"
-                assert not host_check.is_al2023()
+                assert not host_check.is_amazon_linux()
 
-    @pytest.mark.no_is_al2023_mock
+    @pytest.mark.no_is_amazon_linux_mock
     def test_false(self):
         """
         Test the case where the CPE file is found and does not match AL2023.
@@ -4253,11 +4259,11 @@ class TestIsAL2023:
             with mock.patch("pathlib.Path.read_text") as mock_read:
                 mock_exists.return_value = True
                 mock_read.return_value = "cpe:2.3:o:cisco:cisco_linux:2023:foo"
-                assert not host_check.is_al2023()
+                assert not host_check.is_amazon_linux()
 
-    @pytest.mark.no_is_al2023_mock
+    @pytest.mark.no_is_amazon_linux_mock
     def test_not_found(self):
         """Test the case where the CPE file is not found."""
         with mock.patch("pathlib.Path.exists") as mock_exists:
             mock_exists.return_value = False
-            assert not host_check.is_al2023()
+            assert not host_check.is_amazon_linux()

--- a/tests/test_host_check.py
+++ b/tests/test_host_check.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 Cisco Systems Inc.
+# Copyright 2021-2024 Cisco Systems Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Summary

Update host-check with AWS-specific checks. AWS checks are run if OS is Amazon Linux.

Changes:
* Cgroups: now pass for both v1 and v2 everywhere
* Kernel driver: fail if igb_uio is not present when in AWS
* IOMMU: pass instead of warn when in AWS
* Added check of boot cmdline args that checks they match those we set in xrd-packer. This also checks that there are at least 2 isolated CPUs.

Note that the sysctls we set are already tested in host-check but those that tuned sets for us are not. I have not added a test for this as I don't believe we have as strong an opinion about them/have not justified these settings ourselves.

UT written, gives full coverage of changes.

### Example outputs on correctly-setup AWS machine

```
$ ./test.py 
==============================
Platform checks
==============================

base checks
-----------------------
 PASS -- CPU architecture (x86_64)
 PASS -- CPU cores (4)
 PASS -- Kernel version (6.1)
 PASS -- Base kernel modules
         Installed module(s): dummy, nf_tables
 PASS -- Cgroups (v2)
 PASS -- Inotify max user instances
         65536 - this is expected to be sufficient for 16 XRd instance(s).
 PASS -- Inotify max user watches
         65536 - this is expected to be sufficient for 16 XRd instance(s).
 PASS -- Socket kernel parameters (valid settings)
 PASS -- UDP kernel parameters (valid settings)
 INFO -- Core pattern (core files managed by the host)
 PASS -- ASLR (full randomization)
 INFO -- Linux Security Modules (No LSMs are enabled)
 PASS -- Kernel module parameters
         Kernel modules loaded with expected parameters.

xrd-control-plane checks
-----------------------
 PASS -- RAM
         Available RAM is 24.0 GiB.
         This is estimated to be sufficient for 11 XRd instance(s), although memory
         usage depends on the running configuration.
         Note that any swap that may be available is not included.

xrd-vrouter checks
-----------------------
 PASS -- CPU extensions (sse4_1, sse4_2, ssse3)
 PASS -- RAM
         Available RAM is 24.0 GiB.
         This is estimated to be sufficient for 4 XRd instance(s), although memory
         usage depends on the running configuration.
         Note that any swap that may be available is not included.
 PASS -- Hugepages (6 x 1GiB)
 PASS -- Interface kernel driver
         Loaded PCI drivers: vfio-pci, igb_uio
 INFO -- IOMMU
         IOMMU not supported in AWS. It is recommended to use the igb_uio driver.
 PASS -- PCI devices
         The following PCI device(s) are available:
         ens5 (0000:00:05.0), ens6 (0000:00:06.0), ens7 (0000:00:07.0),
         ens8 (0000:00:08.0)
 PASS -- Shared memory pages max size (17179869184.0 GiB)
 PASS -- Real-time Group Scheduling (disabled in kernel config)

AWS host checks for xrd-vrouter
-----------------------
 PASS -- Cmdline arguments
         Expected cmdline args found with isolated cores 2-3

============================================================================
XR platforms supported: xrd-control-plane, xrd-vrouter
============================================================================
```

```
$ ./test.py  -p xrd-control-plane
==============================
Platform checks - xrd-control-plane
==============================
 PASS -- CPU architecture (x86_64)
 PASS -- CPU cores (4)
 PASS -- Kernel version (6.1)
 PASS -- Base kernel modules
         Installed module(s): dummy, nf_tables
 PASS -- Cgroups (v2)
 PASS -- Inotify max user instances
         65536 - this is expected to be sufficient for 16 XRd instance(s).
 PASS -- Inotify max user watches
         65536 - this is expected to be sufficient for 16 XRd instance(s).
 PASS -- Socket kernel parameters (valid settings)
 PASS -- UDP kernel parameters (valid settings)
 INFO -- Core pattern (core files managed by the host)
 PASS -- ASLR (full randomization)
 INFO -- Linux Security Modules (No LSMs are enabled)
 PASS -- Kernel module parameters
         Kernel modules loaded with expected parameters.
 PASS -- RAM
         Available RAM is 24.0 GiB.
         This is estimated to be sufficient for 11 XRd instance(s), although memory
         usage depends on the running configuration.
         Note that any swap that may be available is not included.

============================================================================
Host environment set up correctly for xrd-control-plane
============================================================================
```

```
$ ./test.py  -p xrd-vrouter
==============================
Platform checks - xrd-vrouter
==============================
 PASS -- CPU architecture (x86_64)
 PASS -- CPU cores (4)
 PASS -- Kernel version (6.1)
 PASS -- Base kernel modules
         Installed module(s): dummy, nf_tables
 PASS -- Cgroups (v2)
 PASS -- Inotify max user instances
         65536 - this is expected to be sufficient for 16 XRd instance(s).
 PASS -- Inotify max user watches
         65536 - this is expected to be sufficient for 16 XRd instance(s).
 PASS -- Socket kernel parameters (valid settings)
 PASS -- UDP kernel parameters (valid settings)
 INFO -- Core pattern (core files managed by the host)
 PASS -- ASLR (full randomization)
 INFO -- Linux Security Modules (No LSMs are enabled)
 PASS -- Kernel module parameters
         Kernel modules loaded with expected parameters.
 PASS -- CPU extensions (sse4_1, sse4_2, ssse3)
 PASS -- RAM
         Available RAM is 24.0 GiB.
         This is estimated to be sufficient for 4 XRd instance(s), although memory
         usage depends on the running configuration.
         Note that any swap that may be available is not included.
 PASS -- Hugepages (6 x 1GiB)
 PASS -- Interface kernel driver
         Loaded PCI drivers: vfio-pci, igb_uio
 INFO -- IOMMU
         IOMMU not supported in AWS. It is recommended to use the igb_uio driver.
 PASS -- PCI devices
         The following PCI device(s) are available:
         ens5 (0000:00:05.0), ens6 (0000:00:06.0), ens7 (0000:00:07.0),
         ens8 (0000:00:08.0)
 PASS -- Shared memory pages max size (17179869184.0 GiB)
 PASS -- Real-time Group Scheduling (disabled in kernel config)

AWS host checks
-----------------------
 PASS -- Cmdline arguments
         Expected cmdline args found with isolated cores 2-3

============================================================================
Host environment set up correctly for xrd-vrouter
============================================================================
```

Note that `test.py` contains a copy-pasted version of the host-check script.

### Checklist

<!-- See CONTRIBUTING.md. -->

- [ ] Changelog updated (or not required)
  <!-- Is there any reason a user might care about the change?
       Have you changed any files that go in the release tarball?
       New GH release must be created after merging if new version added to the changelog. 
  -->
- [ ] Static analysis and tests passing
   - Use `commit-check` script, or check GitHub Actions status.
