### PR TITLE
Apply bugfix source help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 The v1 release supports Cisco IOS-XR release versions 7.7.1 and above.
 
+### v1.1.20 (2025-05-09)
+
+- Updated help for apply-bugfixes
+
 ### v1.1.19 (2025-04-22)
 
 - Added Dockerfile.host-check to the release tarball

--- a/scripts/apply-bugfixes
+++ b/scripts/apply-bugfixes
@@ -28,11 +28,17 @@ Create a new XRd image with bugfixes installed on top of a base image.
 
 Required arguments:
   IMAGE            Loaded container image to install bugfixes on top of
-  SOURCE           Bugfix source to install from
+  SOURCE           Bugfix source to install from. This can be:
+                    - an rpm
+                    - a directory containing rpms
+                    - a tarball containing rpms
 
 Optional arguments:
-  --new-packages   Install new packages if included in the bugfix source
-  ...              Args passed through to 'docker build'
+  --new-packages   Install new packages if included in the bugfix source. By
+                   default, only packages that are already installed in the
+                   base image will be updated, so this should be passed if
+                   any new packages are present in SOURCE.
+  ...              Additional args passed through to 'docker build'
 "
 }
 

--- a/scripts/apply-bugfixes
+++ b/scripts/apply-bugfixes
@@ -28,17 +28,21 @@ Create a new XRd image with bugfixes installed on top of a base image.
 
 Required arguments:
   IMAGE            Loaded container image to install bugfixes on top of
-  SOURCE           Bugfix source to install from. This can be:
-                    - an rpm
-                    - a directory containing rpms
-                    - a tarball containing rpms
+  SOURCE           Path to source to install packages from - a directory
+                   or tarball containing the rpm(s) to install.
 
 Optional arguments:
   --new-packages   Install new packages if included in the bugfix source. By
                    default, only packages that are already installed in the
                    base image will be updated, so this should be passed if
                    any new packages are present in SOURCE.
-  ...              Additional args passed through to 'docker build'
+  ...              Additional args passed through to 'docker build' (such as
+                   --tag).
+
+Example invocations:
+  $(basename "$0") ios-xr/xrd-vrouter:25.1.1 /path/to/bugfixes.tar.gz --tag bugfix
+  $(basename "$0") ios-xr/xrd-vrouter:25.1.1 /path/to/rpm-dir/ --tag bugfix
+
 "
 }
 


### PR DESCRIPTION
### Summary

Update help string for apply-bugfixes to explain what the SOURCE argument is and give some examples

Updated output:
```
$ scripts/apply-bugfixes -h

Usage: apply-bugfixes [-h|--help] [--new-packages] IMAGE SOURCE ...

Create a new XRd image with bugfixes installed on top of a base image.

Required arguments:
  IMAGE            Loaded container image to install bugfixes on top of
  SOURCE           Path to source to install packages from - a directory
                   or tarball containing the rpm(s) to install.

Optional arguments:
  --new-packages   Install new packages if included in the bugfix source. By
                   default, only packages that are already installed in the
                   base image will be updated, so this should be passed if
                   any new packages are present in SOURCE.
  ...              Additional args passed through to 'docker build' (such as
                   --tag).

Example invocations:
  apply-bugfixes ios-xr/xrd-vrouter:25.1.1 /path/to/bugfixes.tar.gz --tag bugfix
  apply-bugfixes ios-xr/xrd-vrouter:25.1.1 /path/to/rpm-dir/ --tag bugfix

```


### Checklist

<!-- See CONTRIBUTING.md. -->

- [x] Changelog updated (or not required)
  <!-- Is there any reason a user might care about the change?
       Have you changed any files that go in the release tarball?
       New GH release must be created after merging if new version added to the changelog. 
  -->
- [x] Static analysis and tests passing
   - Use `commit-check` script, or check GitHub Actions status.
